### PR TITLE
Compiler warnings

### DIFF
--- a/include/bg_lib.h
+++ b/include/bg_lib.h
@@ -75,5 +75,6 @@ double	atan2( double y, double x );
 double	tan( double x );
 int		abs( int n );
 double	fabs( double x );
+float	fabsf( float x );
 double	acos( double x );
 

--- a/src/bg_lib.c
+++ b/src/bg_lib.c
@@ -132,6 +132,10 @@ double fabs( double x ) {
 	return x < 0 ? -x : x;
 }
 
+float fabsf( float x ) {
+	return x < 0 ? -x : x;
+}
+
 //=====================================
 
 static int randSeed = 0;

--- a/src/bot_aim.c
+++ b/src/bot_aim.c
@@ -297,8 +297,8 @@ static void BotsModifyAimAtPlayerLogic(gedict_t* self)
 
 		if (g_random() < 0.8) {
 			// Randomise the amount but not the side that we're aiming on
-			yaw_rnd = (self->fb.last_rndaim[YAW] > 0 ? 1 : -1) * abs(yaw_rnd);
-			pitch_rnd = (self->fb.last_rndaim[PITCH] > 0 ? 1 : -1) * abs(pitch_rnd);
+			yaw_rnd = (self->fb.last_rndaim[YAW] > 0 ? 1 : -1) * fabs(yaw_rnd);
+			pitch_rnd = (self->fb.last_rndaim[PITCH] > 0 ? 1 : -1) * fabs(pitch_rnd);
 		}
 
 		self->fb.last_rndaim_time = g_globalvars.time;

--- a/src/bot_aim.c
+++ b/src/bot_aim.c
@@ -289,16 +289,16 @@ static void BotsModifyAimAtPlayerLogic(gedict_t* self)
 		float pitch_diff, yaw_diff;
 		//float lg_percent = (float)self->ps.wpn[wpLG].hits / max(1, self->ps.wpn[wpLG].attacks);
 
-		pitch_diff = bound(pitch->minimum, fabs(raw_pitch_diff) * pitch->scale, pitch->maximum);
-		yaw_diff = bound(yaw->minimum, fabs(raw_yaw_diff) * yaw->scale, yaw->maximum);
+		pitch_diff = bound(pitch->minimum, fabsf(raw_pitch_diff) * pitch->scale, pitch->maximum);
+		yaw_diff = bound(yaw->minimum, fabsf(raw_yaw_diff) * yaw->scale, yaw->maximum);
 
 		pitch_rnd = dist_random(-pitch_diff, pitch_diff, pitch->multiplier * self->fb.skill.current_volatility);
 		yaw_rnd = dist_random(-yaw_diff, yaw_diff, yaw->multiplier * self->fb.skill.current_volatility);
 
 		if (g_random() < 0.8) {
 			// Randomise the amount but not the side that we're aiming on
-			yaw_rnd = (self->fb.last_rndaim[YAW] > 0 ? 1 : -1) * fabs(yaw_rnd);
-			pitch_rnd = (self->fb.last_rndaim[PITCH] > 0 ? 1 : -1) * fabs(pitch_rnd);
+			yaw_rnd = (self->fb.last_rndaim[YAW] > 0 ? 1 : -1) * fabsf(yaw_rnd);
+			pitch_rnd = (self->fb.last_rndaim[PITCH] > 0 ? 1 : -1) * fabsf(pitch_rnd);
 		}
 
 		self->fb.last_rndaim_time = g_globalvars.time;

--- a/src/bot_blocked.c
+++ b/src/bot_blocked.c
@@ -92,7 +92,7 @@ static qbool obstruction(gedict_t* self, vec3_t new_velocity, vec3_t new_origin,
 
 	VectorClear (velocity_normal);
 	VectorSubtract (old_velocity, new_velocity, delta_velocity);
-	if (fabs (delta_velocity[0]) < 0.1 && fabs (delta_velocity[1]) < 0.1)
+	if (fabsf (delta_velocity[0]) < 0.1 && fabsf (delta_velocity[1]) < 0.1)
 	{
 		VectorClear(self->fb.obstruction_normal);
 		return false;
@@ -106,7 +106,7 @@ static qbool obstruction(gedict_t* self, vec3_t new_velocity, vec3_t new_origin,
 	}
 
 	// If not hitting ground...
-	if (fabs(delta_velocity[2]) < 0.1)
+	if (fabsf(delta_velocity[2]) < 0.1)
 	{
 		vec3_t hor_velocity;
 		VectorCopy (new_velocity, hor_velocity);

--- a/src/bot_bothelp.c
+++ b/src/bot_bothelp.c
@@ -117,8 +117,8 @@ gedict_t* HelpTeammate() {
 	self->fb.help_teammate_time = g_globalvars.time + 20 + 3 * g_random();
 	selected1 = NULL;
 	selected2 = NULL;
-	best_dist1 = 99999999;
-	best_dist2 = 99999999;
+	best_dist1 = 99999999.0;
+	best_dist2 = 99999999.0;
 	for (head = world; (head = trap_findradius(head, self->s.v.origin, bdist)); ) {
 		if (head->ct == ctPlayer) {
 			if (SameTeam(head, self)) {

--- a/src/bot_botjump.c
+++ b/src/bot_botjump.c
@@ -43,7 +43,7 @@ static qbool right_direction(gedict_t* self)
 	normalize(direction_to_test_marker, test_direction);
 	desired_direction = vectoyaw(test_direction);
 
-	min_one = fabs(desired_direction - current_direction);
+	min_one = fabsf(desired_direction - current_direction);
 
 	// Reduce angle size and try again, incase one was 20 and the other was 340.. 
 	if (desired_direction >= 180) {
@@ -52,7 +52,7 @@ static qbool right_direction(gedict_t* self)
 	if (current_direction >= 180) {
 		current_direction -= 360;
 	}
-	min_two = fabs(desired_direction - current_direction);
+	min_two = fabsf(desired_direction - current_direction);
 
 	return (qbool)(min(min_one, min_two) <= 90);
 }*/

--- a/src/buttons.c
+++ b/src/buttons.c
@@ -195,7 +195,7 @@ void SP_func_button()
 
 // self->pos1 = self->s.v.origin;
 	VectorCopy( self->s.v.origin, self->pos1 );
-	ftemp = ( fabs( DotProduct( self->s.v.movedir, self->s.v.size ) ) - self->lip );
+	ftemp = ( fabsf( DotProduct( self->s.v.movedir, self->s.v.size ) ) - self->lip );
 
 	self->pos2[0] = self->pos1[0] + self->s.v.movedir[0] * ftemp;
 	self->pos2[1] = self->pos1[1] + self->s.v.movedir[1] * ftemp;

--- a/src/client.c
+++ b/src/client.c
@@ -3429,7 +3429,7 @@ void PlayerPostThink()
 		if ( !match_in_progress && !match_over && !k_captains && !k_matchLess && !isHoonyModeAny() )
 		{
 			if ( iKey( self, "kf" ) & KF_SPEED ) {
-				float velocity_vert_abs	= fabs(self->s.v.velocity[2]);
+				float velocity_vert_abs	= fabsf(self->s.v.velocity[2]);
 				self->s.v.armorvalue	= (int)(velocity < 1000 ? velocity + 1000 : -velocity);
 				self->s.v.frags			= (int)(velocity) / 1000;
 				self->s.v.ammo_shells   = 100 + (int)(velocity_vert_abs) / 100000000;

--- a/src/commands.c
+++ b/src/commands.c
@@ -4589,7 +4589,7 @@ void ktpro_autotrack_predict_powerup( void )
 		return; // we use this function for quad and pent only, ring and suit is not interesting for us
 
 	best = NULL;
-	best_len = 99999999;
+	best_len = 99999999.0;
 
     for( p = world; (p = find_plr( p )); )
 	{

--- a/src/commands.c
+++ b/src/commands.c
@@ -6033,7 +6033,7 @@ void callalias ()
 	}
 
 	trap_CmdArgv( 2, arg_x, sizeof( arg_x ) );
-	tm = fabs( atof(arg_x) );
+	tm = fabsf( atof(arg_x) );
 
 	if ( tm <= 0 || tm > ca_limit2 ) {
 		G_sprint(self, 2, "calling time can't be longer than %d seconds\n", ca_limit2);

--- a/src/doors.c
+++ b/src/doors.c
@@ -190,7 +190,7 @@ void door_fire()
 	do
 	{
 		self->s.v.goalentity = EDICT_TO_PROG( activator );	// Who fired us
-		door_go_up( self );
+		door_go_up();
 		self = PROG_TO_EDICT( self->s.v.enemy );
 	}
 	while ( ( self != starte ) && ( self != world ) );

--- a/src/doors.c
+++ b/src/doors.c
@@ -614,7 +614,7 @@ void SP_func_door()
 	VectorCopy( self->s.v.origin, self->pos1 );
 
 	//
-	tmp = fabs( DotProduct( self->s.v.movedir, self->s.v.size ) ) - self->lip;
+	tmp = fabsf( DotProduct( self->s.v.movedir, self->s.v.size ) ) - self->lip;
 
 	self->pos2[0] = self->pos1[0] + self->s.v.movedir[0] * tmp;
 	self->pos2[1] = self->pos1[1] + self->s.v.movedir[1] * tmp;
@@ -711,14 +711,14 @@ void fd_secret_use( gedict_t * attacker, float take )
 	if ( self->t_width == 0 )
 	{
 		if ( ( int ) ( self->s.v.spawnflags ) & SECRET_1ST_DOWN )
-			self->t_width =  fabs( DotProduct( g_globalvars.v_up, self->s.v.size ) );
+			self->t_width =  fabsf( DotProduct( g_globalvars.v_up, self->s.v.size ) );
 		else
-			self->t_width =  fabs( DotProduct( g_globalvars.v_right, self->s.v.size ));
+			self->t_width =  fabsf( DotProduct( g_globalvars.v_right, self->s.v.size ));
 	}
 
 	if ( self->t_length == 0 )
 		self->t_length =
-		    fabs( DotProduct( g_globalvars.v_forward, self->s.v.size ) );
+		    fabsf( DotProduct( g_globalvars.v_forward, self->s.v.size ) );
 
 	if ( ( int ) ( self->s.v.spawnflags ) & SECRET_1ST_DOWN )
 	{

--- a/src/mathlib.c
+++ b/src/mathlib.c
@@ -68,10 +68,10 @@ void PerpendicularVector( vec3_t dst, const vec3_t src )
 	*/
 	for ( pos = 0, i = 0; i < 3; i++ )
 	{
-		if ( fabs( src[i] ) < minelem )
+		if ( fabsf( src[i] ) < minelem )
 		{
 			pos = i;
-			minelem = fabs( src[i] );
+			minelem = fabsf( src[i] );
 		}
 	}
 	tempvec[0] = tempvec[1] = tempvec[2] = 0.0F;

--- a/src/misc.c
+++ b/src/misc.c
@@ -136,7 +136,7 @@ void SP_light_torch_small_walltorch()
 {
 	trap_precache_model( "progs/flame.mdl" );
 	setmodel( self, "progs/flame.mdl" );
-	FireAmbient( self );
+	FireAmbient();
 	makestatic( self );
 }
 
@@ -148,7 +148,7 @@ void SP_light_flame_large_yellow()
 	trap_precache_model( "progs/flame2.mdl" );
 	setmodel( self, "progs/flame2.mdl" );
 	self->s.v.frame = 1;
-	FireAmbient( self );
+	FireAmbient();
 	makestatic( self );
 }
 
@@ -159,7 +159,7 @@ void SP_light_flame_small_yellow()
 {
 	trap_precache_model( "progs/flame2.mdl" );
 	setmodel( self, "progs/flame2.mdl" );
-	FireAmbient( self );
+	FireAmbient();
 	makestatic( self );
 }
 
@@ -170,7 +170,7 @@ void SP_light_flame_small_white()
 {
 	trap_precache_model( "progs/flame2.mdl" );
 	setmodel( self, "progs/flame2.mdl" );
-	FireAmbient( self );
+	FireAmbient();
 	makestatic( self );
 }
 

--- a/src/sp_hknight.c
+++ b/src/sp_hknight.c
@@ -294,7 +294,7 @@ void CheckForCharge ()
 	if ( g_globalvars.time < self->attack_finished )
 		return;
 
-	if ( fabs( self->s.v.origin[2] - PROG_TO_EDICT( self->s.v.enemy )->s.v.origin[2] ) > 20 )
+	if ( fabsf( self->s.v.origin[2] - PROG_TO_EDICT( self->s.v.enemy )->s.v.origin[2] ) > 20 )
 		return;		// too much height change
 
 	VectorSubtract( PROG_TO_EDICT( self->s.v.enemy )->s.v.origin, self->s.v.origin, delta );	

--- a/src/sp_monsters.c
+++ b/src/sp_monsters.c
@@ -870,14 +870,14 @@ void monster_start_go( monsterType_t mt )
 		}
 		else
 		{
-			self->pausetime = 99999999;
+			self->pausetime = 99999999.0;
 			if ( self->th_stand )
 				self->th_stand();
 		}
 	}
 	else
 	{
-		self->pausetime = 99999999;
+		self->pausetime = 99999999.0;
 		if ( self->th_stand )
 			self->th_stand();
 	}

--- a/src/subs.c
+++ b/src/subs.c
@@ -53,7 +53,7 @@ void InitTrigger()
 // trigger angles are used for one-way touches.  An angle of 0 is assumed
 // to mean no restrictions, so use a yaw of 360 instead.
 	if ( !VectorCompareF( self->s.v.angles, 0, 0, 0 ) )
-		SetMovedir( self );
+		SetMovedir();
 	self->s.v.solid = SOLID_TRIGGER;
 	setmodel( self, self->model );	// set size and link into world
 	self->s.v.movetype = MOVETYPE_NONE;


### PR DESCRIPTION
I came across some compiler warnings while getting ready to submit a port for ktx for OpenBSD. @tdm4 is the maintainer of mvdsv on OpenBSD and let me know about the PR.

This fixes:
-  Credit goes to @tdm4 for fixing the abs() issue here: https://github.com/deurk/mvdsv/commit/5ff1935dca0a839d13cb0de12864b26117b97d1b
- warning: implicit conversion from 'int' to 'float' changes value from 99999999 to 1.0E+8 [-Wimplicit-int-float-conversion]
- warning: too many arguments in call to 'FireAmbient'

warnings here: https://gist.github.com/namtsui/e5edb677c0a70bc514df1614affb971c

These are not fixed but seem harmless: warning: illegal character encoding in string literal