### PR TITLE
QE: add k_no_scoreboard_ghosts cvar

### DIFF
--- a/src/g_utils.c
+++ b/src/g_utils.c
@@ -2234,6 +2234,11 @@ void ghostClearScores(gedict_t *g)
 	int to = MSG_ALL;
 	int cl_slot = g->ghost_slot;
 
+	if (cvar_string("k_no_scoreboard_ghosts")[0])
+	{
+		return; // Scoreboard ghosts disabled, probably for QE compatibility.
+	}
+
 	if (strneq(g->classname, "ghost"))
 	{
 		return;
@@ -2262,6 +2267,11 @@ void ghost2scores(gedict_t *g)
 {
 	int to = MSG_ALL;
 	int cl_slot;
+
+	if (cvar_string("k_no_scoreboard_ghosts")[0])
+	{
+		return; // Scoreboard ghosts disabled, probably for QE compatibility.
+	}
 
 	if (isRA())
 	{

--- a/src/world.c
+++ b/src/world.c
@@ -1034,6 +1034,8 @@ void FirstFrame()
 // }
 #endif
 
+	RegisterCvar("k_no_scoreboard_ghosts");
+
 	RegisterCvar("k_lgcmode");
 
 	// private games


### PR DESCRIPTION
k_no_scoreboard_ghosts toggles ghosts (fake players during disconnect) for scoreboard.
Ghosts cause disconnects for QE so disabling them is a workaround.