### PR TITLE
BUILD: Bump cmake req to 3.9.0 to allow LTO.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.4.0)
+cmake_minimum_required(VERSION 3.9.0)
 
 # Set project name and languge.
 project(qwprogs C)

--- a/tools/q3asm/CMakeLists.txt
+++ b/tools/q3asm/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.4.0)
+cmake_minimum_required(VERSION 3.9.0)
 
 project(q3asm C)
 add_executable(q3asm q3asm.c q3vm.c cmdlib.c)

--- a/tools/q3lcc/CMakeLists.txt
+++ b/tools/q3lcc/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.4.0)
+cmake_minimum_required(VERSION 3.9.0)
 
 project(q3lcc C)
 


### PR DESCRIPTION
Unlocks optional longer compile times. cmake 3.9.0 was released Nov 30, 2018, so far from bleeding edge - CI is on 3.10.2.

```
cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_INTERPROCEDURAL_OPTIMIZATION=1 ..
```

Previous output:
```
CMake Warning (dev) at CMakeLists.txt:130 (add_library):
  Policy CMP0069 is not set: INTERPROCEDURAL_OPTIMIZATION is enforced when
  enabled.  Run "cmake --help-policy CMP0069" for policy details.  Use the
  cmake_policy command to set the policy and suppress this warning.

  INTERPROCEDURAL_OPTIMIZATION property will be ignored for target 'qwprogs'.
This warning is for project developers.  Use -Wno-dev to suppress it.
```