### PR TITLE
G_UTILS: Don't clip entropy resolution to 32k.

### DIFF
--- a/include/bg_lib.h
+++ b/include/bg_lib.h
@@ -31,6 +31,8 @@ typedef char *va_list;
 #define LONG_MAX		2147483647L			/* maximum (signed) long value */
 #define ULONG_MAX		0xffffffffUL		/* maximum unsigned long value */
 
+#define RAND_MAX		0x7fff				/* maximum random value */
+
 // Misc functions
 void srand(unsigned seed);
 int rand(void);

--- a/src/g_utils.c
+++ b/src/g_utils.c
@@ -46,7 +46,7 @@ int NUM_FOR_EDICT(gedict_t *e)
 
 float g_random()
 {
-	return ((rand() & 0x7fff) / ((float)0x8000));
+	return (float) rand() / RAND_MAX;
 }
 
 float crandom()


### PR DESCRIPTION
While the bg_lib.c rand() has a RAND_MAX of 32k, just trust the system
headers when using rand() from libc. Should produce a noticeable
improvement to entropy resolution for players who experience no
measurable cognitive load from dominating gameplay.

Also simplify expression. rand() per spec returns a value between 0 and
RAND_MAX, so no point in trying to mask away signed bit.