### PR TITLE
CTF: Add a more flexible version of CTF based spawn.

### DIFF
--- a/src/g_spawn.c
+++ b/src/g_spawn.c
@@ -403,6 +403,9 @@ spawn_t spawns[] =
 	{ "func_ctf_wall", 					SP_func_ctf_wall },
 	{ "info_player_team1", 				SUB_Null },
 	{ "info_player_team2", 				SUB_Null },
+// k_ctf_based_spawn 2 "within home base" spawns.
+	{ "info_player_team1_deathmatch", 	SUB_Null },
+	{ "info_player_team2_deathmatch", 	SUB_Null },
 //
 // TF -- well, we does not support TF but require it for loading TF map as CTF map.
 //

--- a/src/runes.c
+++ b/src/runes.c
@@ -287,7 +287,7 @@ gedict_t* SelectRuneSpawnPoint()
 {
 	gedict_t *runespawn;
 
-	if (cvar("k_ctf_based_spawn"))
+	if (cvar("k_ctf_based_spawn") == 1)
 	{
 		runespawn = SelectSpawnPoint(g_random() < 0.5 ? "info_player_team1" : "info_player_team2");
 	}


### PR DESCRIPTION
This introduces k_ctf_based_spawn 2 which utilizes three types of
spawn points.

1. info_player_deathmatch
    Neutral territory, typically mid section of map.
2. info_player_team(1|2)
    Start position, typically a balanced distance to powerups. A very
    poor match for deathmatch spawns if enemy is in your base with quad
    and strength and you respawn in pretty much the same place every time.
3. info_player_team(1|2)_deathmatch
    Additional spawn positions that would be offensive for the opposing
    team to spawn at during game, typically within your home base.

At start, it works as regular CTF spawns, but once match has started and
a player is respawned the selection has a 50/50 chance of spawning at a
neutral spawn point or at a spawn point within your home base.

Runes will like the traditional mode only spawn at neutral spawn points.