### PR TITLE
RUNES: Let mappers dictate rune spawns.

### DIFF
--- a/src/g_spawn.c
+++ b/src/g_spawn.c
@@ -400,6 +400,10 @@ spawn_t spawns[] =
 // ctf ents
 	{ "item_flag_team1", 				SP_item_flag_team1 },
 	{ "item_flag_team2", 				SP_item_flag_team2 },
+	{ "item_rune_res", 					SUB_Null },
+	{ "item_rune_str", 					SUB_Null },
+	{ "item_rune_hst", 					SUB_Null },
+	{ "item_rune_rgn", 					SUB_Null },
 	{ "func_ctf_wall", 					SP_func_ctf_wall },
 	{ "info_player_team1", 				SUB_Null },
 	{ "info_player_team2", 				SUB_Null },

--- a/src/runes.c
+++ b/src/runes.c
@@ -12,12 +12,40 @@ gedict_t* SelectRuneSpawnPoint();
 
 void DoDropRune(int rune, qbool s)
 {
-	gedict_t *item;
+	gedict_t *item, *pos = NULL;
+	float movetype = MOVETYPE_NONE;
 
 	cl_refresh_plus_scores(self);
 
+	if (s)
+	{
+		if (rune & CTF_RUNE_RES)
+		{
+			pos = ez_find(world, "item_rune_res");
+		}
+		else if (rune & CTF_RUNE_STR)
+		{
+			pos = ez_find(world, "item_rune_str");
+		}
+		else if (rune & CTF_RUNE_HST)
+		{
+			pos = ez_find(world, "item_rune_hst");
+		}
+		else if (rune & CTF_RUNE_RGN)
+		{
+			pos = ez_find(world, "item_rune_rgn");
+		}
+	}
+
+	// No dedicated rune position found, just toss on self
+	if (pos == NULL)
+	{
+		pos = self;
+		movetype = MOVETYPE_TOSS;
+	}
+
 	item = spawn();
-	setorigin(item, self->s.v.origin[0], self->s.v.origin[1], self->s.v.origin[2] - 24);
+	setorigin(item, pos->s.v.origin[0], pos->s.v.origin[1], pos->s.v.origin[2] - 24);
 	item->classname = "rune";
 	item->ctf_flag = rune;
 	item->s.v.velocity[0] = i_rnd(-100, 100);
@@ -25,7 +53,7 @@ void DoDropRune(int rune, qbool s)
 	item->s.v.velocity[2] = 400;
 	item->s.v.flags = FL_ITEM;
 	item->s.v.solid = SOLID_TRIGGER;
-	item->s.v.movetype = MOVETYPE_TOSS;
+	item->s.v.movetype = movetype;
 
 	if (rune & CTF_RUNE_RES)
 	{


### PR DESCRIPTION
More than once there has been discussions on rune spawns and how they
randomly might give one of the teams an upper hand.

This feature gives mappers the ability to integrate rune spawn positions
into the map design that will be used whenever a rune (re)spawns.

Dropping a rune still drops it on the ground, but if not picked up, the
regular timeout will cause the rune to respawn at a dedicated position if
such a position is available.