### PR TITLE
CTF: Add support for destroying flags and runes.

### DIFF
--- a/src/triggers.c
+++ b/src/triggers.c
@@ -932,12 +932,31 @@ void hurt_on()
 	self->s.v.solid = SOLID_TRIGGER;
 	self->s.v.nextthink = -1;
 	setorigin(self, PASSVEC3(self->s.v.origin)); // it matter
+	g_globalvars.force_retouch = 2; // make sure even still objects get hit
+}
+
+void hurt_items()
+{
+	if (cvar("k_ctf_hurt_items"))
+	{
+		if (streq(other->classname, "item_flag_team1") || streq(other->classname, "item_flag_team2"))
+		{
+			// Cause flag to return to spawn position.
+			other->super_time = g_globalvars.time;
+		}
+		else if (streq(other->classname, "rune"))
+		{
+			// Cause rune to respawn.
+			other->s.v.nextthink = g_globalvars.time;
+		}
+	}
 }
 
 void hurt_touch()
 {
 	if (!other->s.v.takedamage)
 	{
+		hurt_items();
 		return;
 	}
 

--- a/src/world.c
+++ b/src/world.c
@@ -925,6 +925,7 @@ void FirstFrame()
 	RegisterCvarEx("k_ctf_rune_power_hst", "2.0");
 	RegisterCvar("k_ctf_ga");
 	RegisterCvar("k_ctf_based_spawn"); // spawn players on the base (red/blue)
+	RegisterCvar("k_ctf_hurt_items");
 //}
 	RegisterCvar("k_spec_info");
 	RegisterCvar("k_midair");


### PR DESCRIPTION
When k_ctf_hurt_items is enabled both flags and runes will instantly
respawn when touching a trigger_hurt.

The use case is open maps where such items may fall into the void and
you don't want to wait for the rune and flag timeouts.