### PR TITLE
CTF: Make it possible to disable individual runes.

### DIFF
--- a/src/runes.c
+++ b/src/runes.c
@@ -317,14 +317,29 @@ void SpawnRunes(qbool yes)
 
 	oself = self;
 
-	self = SelectRuneSpawnPoint();
-	DoDropRune( CTF_RUNE_RES, true);
-	self = SelectRuneSpawnPoint();
-	DoDropRune( CTF_RUNE_STR, true);
-	self = SelectRuneSpawnPoint();
-	DoDropRune( CTF_RUNE_HST, true);
-	self = SelectRuneSpawnPoint();
-	DoDropRune( CTF_RUNE_RGN, true);
+	if (cvar("k_ctf_rune_power_res") > 0)
+	{
+		self = SelectRuneSpawnPoint();
+		DoDropRune( CTF_RUNE_RES, true);
+	}
+
+	if (cvar("k_ctf_rune_power_str") > 0)
+	{
+		self = SelectRuneSpawnPoint();
+		DoDropRune( CTF_RUNE_STR, true);
+	}
+
+	if (cvar("k_ctf_rune_power_hst") > 0)
+	{
+		self = SelectRuneSpawnPoint();
+		DoDropRune( CTF_RUNE_HST, true);
+	}
+
+	if (cvar("k_ctf_rune_power_rgn") > 0)
+	{
+		self = SelectRuneSpawnPoint();
+		DoDropRune( CTF_RUNE_RGN, true);
+	}
 
 	self = oself;
 }


### PR DESCRIPTION
Setting any of the existing `k_ctf_rune_power_*` to `0` prevents spawning of this rune.