### PR TITLE
RUNES: Randomized rune spawns.

### DIFF
--- a/src/runes.c
+++ b/src/runes.c
@@ -41,7 +41,7 @@ void DoDropRune(int rune, qbool s)
 	if (pos == NULL)
 	{
 		pos = self;
-		movetype = MOVETYPE_TOSS;
+		movetype = (int) cvar("k_ctf_rune_bounce") & 1 ? MOVETYPE_BOUNCE : MOVETYPE_TOSS;
 	}
 
 	item = spawn();
@@ -95,7 +95,7 @@ void DoTossRune(int rune)
 	item->classname = "rune";
 	item->s.v.flags = FL_ITEM;
 	item->s.v.solid = SOLID_TRIGGER;
-	item->s.v.movetype = MOVETYPE_TOSS;
+	item->s.v.movetype = (int) cvar("k_ctf_rune_bounce") & 2 ? MOVETYPE_BOUNCE : MOVETYPE_TOSS;
 
 	trap_makevectors(self->s.v.v_angle);
 

--- a/src/runes.c
+++ b/src/runes.c
@@ -8,7 +8,8 @@ void RegenLostRot();
 void RuneRespawn();
 void RuneTouch();
 void RuneResetOwner();
-gedict_t* SelectRuneSpawnPoint();
+gedict_t* SelectSpawnPoint();
+char* GetRuneSpawnName();
 
 void DoDropRune(int rune, qbool s)
 {
@@ -229,7 +230,7 @@ void RuneRespawn()
 	int rune = self->ctf_flag;
 
 	ent_remove(self);
-	self = SelectRuneSpawnPoint();
+	self = SelectSpawnPoint(GetRuneSpawnName());
 	DoDropRune(rune, true);
 }
 
@@ -310,19 +311,18 @@ void RuneTouch()
 	ent_remove(self);
 }
 
-gedict_t* SelectSpawnPoint();
-gedict_t* SelectRuneSpawnPoint()
+char* GetRuneSpawnName()
 {
-	gedict_t *runespawn;
+	char *runespawn;
 
 	if (cvar("k_ctf_based_spawn") == 1)
 	{
-		runespawn = SelectSpawnPoint(g_random() < 0.5 ? "info_player_team1" : "info_player_team2");
+		runespawn = g_random() < 0.5 ? "info_player_team1" : "info_player_team2";
 	}
 	else
 	{
 		// we'll just use the player spawn point selector for runes as well
-		runespawn = SelectSpawnPoint("info_player_deathmatch");
+		runespawn = "info_player_deathmatch";
 	}
 
 	return runespawn;
@@ -347,25 +347,25 @@ void SpawnRunes(qbool yes)
 
 	if (cvar("k_ctf_rune_power_res") > 0)
 	{
-		self = SelectRuneSpawnPoint();
+		self = SelectSpawnPoint(GetRuneSpawnName());
 		DoDropRune( CTF_RUNE_RES, true);
 	}
 
 	if (cvar("k_ctf_rune_power_str") > 0)
 	{
-		self = SelectRuneSpawnPoint();
+		self = SelectSpawnPoint(GetRuneSpawnName());
 		DoDropRune( CTF_RUNE_STR, true);
 	}
 
 	if (cvar("k_ctf_rune_power_hst") > 0)
 	{
-		self = SelectRuneSpawnPoint();
+		self = SelectSpawnPoint(GetRuneSpawnName());
 		DoDropRune( CTF_RUNE_HST, true);
 	}
 
 	if (cvar("k_ctf_rune_power_rgn") > 0)
 	{
-		self = SelectRuneSpawnPoint();
+		self = SelectSpawnPoint(GetRuneSpawnName());
 		DoDropRune( CTF_RUNE_RGN, true);
 	}
 

--- a/src/world.c
+++ b/src/world.c
@@ -920,6 +920,7 @@ void FirstFrame()
 	RegisterCvar("k_ctf_hook");
 	RegisterCvar("k_ctf_hookstyle"); // loop through hookstyle settings
 	RegisterCvar("k_ctf_runes");
+	RegisterCvarEx("k_ctf_rune_bounce", "3");
 	RegisterCvarEx("k_ctf_rune_power_str", "2.0");
 	RegisterCvarEx("k_ctf_rune_power_res", "2.0");
 	RegisterCvarEx("k_ctf_rune_power_rgn", "2.0");


### PR DESCRIPTION
Runes spawn at either designated `item_rune_$name` spawn points, or `info_player_deathmatch`, and usually there aren't that many to pick from which results in a fairly high probability that multiple runes spawn at the same spawn point, and worst case this spawn point is on the way between base and quad at map start.

This PR introduces unique spawn point selection at match start for runes, and secondly also ports the PureCTF functionality of bouncing runes which further improves the randomization by causing runes to sometimes bounce down ledges etc. 