### PR TITLE
Additional ents

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -71,6 +71,7 @@ set(SRC_COMMON
 	"${DIR_SRC}/g_spawn.c"
 	"${DIR_SRC}/g_userinfo.c"
 	"${DIR_SRC}/g_utils.c"
+	"${DIR_SRC}/hiprot.c"
 	"${DIR_SRC}/hoonymode.c"
 	"${DIR_SRC}/items.c"
 	"${DIR_SRC}/logs.c"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -64,6 +64,7 @@ set(SRC_COMMON
 	"${DIR_SRC}/doors.c"
 	"${DIR_SRC}/fb_globals.c"
 	"${DIR_SRC}/files.c"
+	"${DIR_SRC}/func_bob.c"
 	"${DIR_SRC}/g_cmd.c"
 	"${DIR_SRC}/globals.c"
 	"${DIR_SRC}/g_mem.c"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -65,6 +65,7 @@ set(SRC_COMMON
 	"${DIR_SRC}/fb_globals.c"
 	"${DIR_SRC}/files.c"
 	"${DIR_SRC}/func_bob.c"
+	"${DIR_SRC}/func_laser.c"
 	"${DIR_SRC}/g_cmd.c"
 	"${DIR_SRC}/globals.c"
 	"${DIR_SRC}/g_mem.c"

--- a/include/progs.h
+++ b/include/progs.h
@@ -1222,6 +1222,11 @@ typedef struct gedict_s
 // { ambient_general
 	float volume;
 // }
+
+// { trigger_heal
+	float healmax;
+	float healtimer;
+// }
 } gedict_t;
 
 typedef enum

--- a/include/progs.h
+++ b/include/progs.h
@@ -1218,6 +1218,10 @@ typedef struct gedict_s
 	float waitmin;
 	float waitmin2;
 // }
+
+// { ambient_general
+	float volume;
+// }
 } gedict_t;
 
 typedef enum

--- a/include/progs.h
+++ b/include/progs.h
@@ -1212,6 +1212,12 @@ typedef struct gedict_s
 	string_t path;
 	string_t event;
 // }
+
+// { func_bob
+	float distance;
+	float waitmin;
+	float waitmin2;
+// }
 } gedict_t;
 
 typedef enum

--- a/include/progs.h
+++ b/include/progs.h
@@ -1200,6 +1200,18 @@ typedef struct gedict_s
 // {
 	qbool spawn_effect_queued;
 // }
+
+// { hiprot fields
+	int rotate_type;
+	vec3_t neworigin;
+	vec3_t rotate;
+	vec3_t finalangle;
+	float endtime;
+	float duration;
+	string_t group;
+	string_t path;
+	string_t event;
+// }
 } gedict_t;
 
 typedef enum

--- a/include/progs.h
+++ b/include/progs.h
@@ -1202,30 +1202,30 @@ typedef struct gedict_s
 // }
 
 // { hiprot fields
-	int rotate_type;
-	vec3_t neworigin;
-	vec3_t rotate;
-	vec3_t finalangle;
-	float endtime;
-	float duration;
-	string_t group;
-	string_t path;
-	string_t event;
+	int rotate_type;                        // internal, rotate(0), movewall(1), setorigin(2), see hiprot.c
+	vec3_t neworigin;                       // internal, origin tracking
+	vec3_t rotate;                          // rotation angle
+	vec3_t finalangle;                      // normalized version of 'angles'
+	float endtime;                          // internal, animation tracking
+	float duration;                         // internal, animation tracking
+	string_t group;                         // linking of rotating brushes
+	string_t path;                          // from ent field 'target', as 'path' to mirror original source
+	string_t event;                         // events that may happen at path corners
 // }
 
 // { func_bob
-	float distance;
-	float waitmin;
-	float waitmin2;
+	float distance;                         // distance between vantage points
+	float waitmin;                          // speed-up factor, >0, see func_bob.c for defaults
+	float waitmin2;                         // slowdown factor, >0, see func_bob.c for defaults
 // }
 
 // { ambient_general
-	float volume;
+	float volume;                           // attenuation, see misc.c for defaults
 // }
 
 // { trigger_heal
-	float healmax;
-	float healtimer;
+	float healmax;                          // maximum health see triggers.c for defaults
+	float healtimer;                        // internal timer for tracking health replenishment interval
 // }
 } gedict_t;
 

--- a/include/q_shared.h
+++ b/include/q_shared.h
@@ -123,7 +123,7 @@ size_t strlcat(char *dst, char *src, size_t siz);
 #define	MAX_QPATH		64			// max length of a quake game pathname
 #define	MAX_OSPATH		128			// max length of a filesystem pathname
 
-#define	MAX_EDICTS		768			// FIXME: ouch! ouch! ouch!
+#define	MAX_EDICTS		2048
 #define	MAX_LIGHTSTYLES	64
 #define	MAX_MODELS		256			// these are sent over the net as bytes
 #define	MAX_SOUNDS		256			// so they cannot be blindly increased

--- a/src/func_bob.c
+++ b/src/func_bob.c
@@ -11,7 +11,7 @@ static void func_bob_timer()
 	{
 		// Setup bob cycle and half way point for slowdown
 		self->endtime = g_globalvars.time + self->count;
-		self->distance = g_globalvars.time + (self->count * 0.5);
+		self->distance = g_globalvars.time + (self->count * 0.5f);
 
 		// Flip direction of bmodel bob
 		self->lefty = 1 - self->lefty;
@@ -41,7 +41,7 @@ static void func_bob_timer()
 		VectorAdd(self->s.v.velocity, delta, self->s.v.velocity);
 	}
 
-	self->s.v.nextthink = self->s.v.ltime + 0.1;
+	self->s.v.nextthink = self->s.v.ltime + 0.1f;
 }
 
 void SP_func_bob()
@@ -69,7 +69,7 @@ void SP_func_bob()
 	}
 	if (self->waitmin2 <= 0)
 	{
-		self->waitmin2 = 0.75; // Slow down
+		self->waitmin2 = 0.75f; // Slow down
 	}
 	if (self->delay < 0)
 	{

--- a/src/func_bob.c
+++ b/src/func_bob.c
@@ -1,0 +1,81 @@
+#include "g_local.h"
+
+// Stripped down port of dumptruckDS's func_bob.qc
+
+static void func_bob_timer()
+{
+	vec3_t delta;
+
+	// Has the cycle completed?
+	if (self->endtime < g_globalvars.time)
+	{
+		// Setup bob cycle and half way point for slowdown
+		self->endtime = g_globalvars.time + self->count;
+		self->distance = g_globalvars.time + (self->count * 0.5);
+
+		// Flip direction of bmodel bob
+		self->lefty = 1 - self->lefty;
+		if (self->lefty < 1)
+		{
+			self->t_length = self->height;
+		}
+		else
+		{
+			self->t_length = -self->height;
+		}
+
+		// Always reset velocity at pivot
+		SetVector(self->s.v.velocity, 0, 0, 0);
+	}
+
+	if (self->distance < g_globalvars.time)
+	{
+		// Slow down velocity (gradually)
+		VectorScale(self->s.v.velocity, self->waitmin2, self->s.v.velocity);
+	}
+	else
+	{
+		// Speed up velocity (linear/exponentially)
+		self->t_length *= self->waitmin;
+		VectorScale(self->s.v.movedir, self->t_length, delta);
+		VectorAdd(self->s.v.velocity, delta, self->s.v.velocity);
+	}
+
+	self->s.v.nextthink = self->s.v.ltime + 0.1;
+}
+
+void SP_func_bob()
+{
+	self->s.v.movetype = MOVETYPE_PUSH;
+	self->s.v.solid = SOLID_BSP;
+
+	setmodel(self, self->model);
+	setsize(self, PASSVEC3(self->s.v.mins), PASSVEC3(self->s.v.maxs));
+
+	SetMovedir();
+	VectorNormalize(self->s.v.movedir);
+
+	if (self->height <= 0)
+	{
+		self->height = 8; // Direction intensity
+	}
+	if (self->count < 1)
+	{
+		self->count = 2; // Direction switch timer
+	}
+	if (self->waitmin <= 0)
+	{
+		self->waitmin = 1; // Speed up
+	}
+	if (self->waitmin2 <= 0)
+	{
+		self->waitmin2 = 0.75; // Slow down
+	}
+	if (self->delay < 0)
+	{
+		self->delay = g_random() + g_random() + g_random();
+	}
+
+	self->think = (func_t) func_bob_timer;
+	self->s.v.nextthink = g_globalvars.time + 0.1 + self->delay;
+}

--- a/src/func_laser.c
+++ b/src/func_laser.c
@@ -1,0 +1,154 @@
+#include "g_local.h"
+
+#define START_OFF 1
+#define LASER_SOLID 2
+
+static void laser_helper_think()
+{
+	gedict_t *owner = PROG_TO_EDICT(self->s.v.owner);
+	float alpha = trap_GetExtField_f(self, "alpha");
+
+	if (!((int) owner->s.v.spawnflags & START_OFF))
+	{
+		trap_SetExtField_f(self, "alpha", alpha * 0.8 + alpha * g_random() * 0.4);
+	}
+
+	self->s.v.nextthink = g_globalvars.time + 0.05;
+}
+
+static void init_laser_noise()
+{
+	gedict_t *owner = PROG_TO_EDICT(self->s.v.owner);
+
+	sound(owner, CHAN_VOICE, owner->noise, 1, ATTN_NORM);
+
+	self->think = (func_t) laser_helper_think;
+	self->s.v.nextthink = g_globalvars.time + 0.05;
+}
+
+static void func_laser_touch()
+{
+	// from Copper -- dumptruck_ds
+	if (other->s.v.movetype == MOVETYPE_NOCLIP)
+	{
+			return;
+	}
+
+	if (other->s.v.takedamage && self->attack_finished < g_globalvars.time)
+	{
+		T_Damage (other, self, self, self->dmg);
+		// add "zap" sound when damage is dealt
+		sound (self, CHAN_WEAPON, self->noise2, 1, ATTN_NORM);
+		self->attack_finished = g_globalvars.time + 0.333;
+	}
+}
+
+static void func_laser_use()
+{
+	if ((int) self->s.v.spawnflags & START_OFF)
+	{
+		setorigin(self, 0, 0, 0);
+		self->s.v.spawnflags = self->s.v.spawnflags - START_OFF;
+		sound(self, CHAN_VOICE, self->noise, 1, ATTN_NORM);
+	}
+	else
+	{
+		sound (self, CHAN_VOICE, self->noise1, 1, ATTN_NORM);
+		setorigin(self, 0, 0, 9000);
+		self->s.v.spawnflags = self->s.v.spawnflags + START_OFF;
+	}
+};
+
+/**
+ * QUAKED func_laser (0 .5 .8) ? START_OFF LASER_SOLID X X X X X X NOT_ON_EASY NOT_ON_NORMAL NOT_ON_HARD_OR_NIGHTMARE NOT_IN_DEATHMATCH NOT_IN_COOP NOT_IN_SINGLEPLAYER X NOT_ON_HARD_ONLY NOT_ON_NIGHTMARE_ONLY
+ * A toggleable laser, hurts to touch, can be used to block players
+ * START_OFF: Laser starts off.
+ * LASER_SOLID: Laser blocks movement while turned on.
+ * Keys:
+ * "dmg" damage to do on touch. default 1
+ * "alpha" approximate alpha you want the laser drawn at. default 0.5. alpha will vary by 20% of this value.
+ * "message" message to display when activated (not supported)
+ * "message2" message to display when deactivated (not supported)
+ */
+void SP_func_laser()
+{
+	gedict_t *helper;
+	float alpha;
+
+	setmodel(self, self->model);
+
+	trap_precache_sound ("buttons/switch02.wav");
+	trap_precache_sound ("buttons/switch04.wav");
+	trap_precache_sound ("misc/null.wav");
+
+	if ((int) self->s.v.spawnflags & LASER_SOLID)
+	{
+		self->s.v.solid = SOLID_BSP; //so you can shoot between lasers in a single bmodel
+		self->s.v.movetype = MOVETYPE_PUSH; //required becuase of SOLID_BSP
+	}
+	else
+	{
+		self->s.v.solid = SOLID_TRIGGER;
+		self->s.v.movetype = MOVETYPE_NONE;
+	}
+
+	alpha = trap_GetExtField_f(self, "alpha");
+	if (!alpha)
+	{
+		alpha = 0.5;
+	}
+	trap_SetExtField_f(self, "alpha", alpha);
+
+	if (!self->dmg)
+	{
+		self->dmg = 1;
+	}
+
+	self->use = (func_t) func_laser_use;
+	self->touch = (func_t) func_laser_touch;
+
+	if ((int) self->s.v.spawnflags & START_OFF)
+	{
+		setorigin(self, 0, 0, 9000);
+	}
+	else
+	{
+		setorigin(self, 0, 0, 0);
+	}
+
+	if (!strnull(self->noise))
+	{
+		trap_precache_sound(self->noise);
+	}
+	else
+	{
+		self->noise = "buttons/switch02.wav";
+	}
+
+	if (!strnull(self->noise1))
+	{
+		trap_precache_sound(self->noise1);
+	}
+	else
+	{
+		self->noise1 = "buttons/switch04.wav";
+	}
+
+	if (!strnull(self->noise2))
+	{
+		trap_precache_sound(self->noise2);
+	}
+	else
+	{
+		self->noise2 = "misc/null.wav";
+	}
+
+	//spawn a second entity to handle alpha changes, since MOVETYPE_PUSH doesn't support think functions
+	helper = spawn();
+	helper->s.v.owner = EDICT_TO_PROG(self);
+	helper->s.v.nextthink = g_globalvars.time + 2;
+
+	trap_SetExtField_f(helper, "alpha", alpha);
+
+	helper->think = (func_t) init_laser_noise;
+}

--- a/src/func_laser.c
+++ b/src/func_laser.c
@@ -10,10 +10,10 @@ static void laser_helper_think()
 
 	if (!((int) owner->s.v.spawnflags & START_OFF))
 	{
-		trap_SetExtField_f(self, "alpha", alpha * 0.8 + alpha * g_random() * 0.4);
+		trap_SetExtField_f(self, "alpha", alpha * 0.8f + alpha * g_random() * 0.4f);
 	}
 
-	self->s.v.nextthink = g_globalvars.time + 0.05;
+	self->s.v.nextthink = g_globalvars.time + 0.05f;
 }
 
 static void init_laser_noise()
@@ -23,7 +23,7 @@ static void init_laser_noise()
 	sound(owner, CHAN_VOICE, owner->noise, 1, ATTN_NORM);
 
 	self->think = (func_t) laser_helper_think;
-	self->s.v.nextthink = g_globalvars.time + 0.05;
+	self->s.v.nextthink = g_globalvars.time + 0.05f;
 }
 
 static void func_laser_touch()
@@ -39,7 +39,7 @@ static void func_laser_touch()
 		T_Damage (other, self, self, self->dmg);
 		// add "zap" sound when damage is dealt
 		sound (self, CHAN_WEAPON, self->noise2, 1, ATTN_NORM);
-		self->attack_finished = g_globalvars.time + 0.333;
+		self->attack_finished = g_globalvars.time + 0.333f;
 	}
 }
 
@@ -95,7 +95,7 @@ void SP_func_laser()
 	alpha = trap_GetExtField_f(self, "alpha");
 	if (!alpha)
 	{
-		alpha = 0.5;
+		alpha = 0.5f;
 	}
 	trap_SetExtField_f(self, "alpha", alpha);
 

--- a/src/g_spawn.c
+++ b/src/g_spawn.c
@@ -124,6 +124,14 @@ field_t fields[] =
 	{ "angle", 						FOFS(s.v.angles), 					F_ANGLEHACK },
 	{ "light", 						0, 									F_IGNORE },
 	{ "wad", 						0, 									F_IGNORE },
+	{ "noise",						FOFS(noise), 						F_LSTRING },
+	{ "noise1",						FOFS(noise1), 						F_LSTRING },
+	{ "noise2",						FOFS(noise2), 						F_LSTRING },
+	{ "noise3",						FOFS(noise3), 						F_LSTRING },
+	{ "noise4",						FOFS(noise4), 						F_LSTRING },
+	{ "deathtype",					FOFS(deathtype), 					F_LSTRING },
+	{ "t_length",					FOFS(t_length), 					F_FLOAT },
+	{ "t_width",					FOFS(t_width), 						F_FLOAT },
 // TF
 	{ "team_no", 					FOFS(team_no), 						F_INT },
 // custom teleporters

--- a/src/g_spawn.c
+++ b/src/g_spawn.c
@@ -174,6 +174,9 @@ field_t fields[] =
 
 // ambient_general
 	{ "volume", 					FOFS(volume), 						F_FLOAT },
+
+// trigger_heal
+	{ "heal_amount", 				FOFS(healamount), 					F_FLOAT },
 	{ NULL }
 };
 
@@ -340,6 +343,8 @@ void SP_func_rotate_door();
 
 void SP_ambient_general();
 
+void SP_trigger_heal();
+
 spawn_t spawns[] =
 {
 // info entities don't do anything at all, but provide positional
@@ -494,6 +499,8 @@ spawn_t spawns[] =
 	{ "func_rotate_door", SP_func_rotate_door },
 	{ "func_rotate_train", SP_func_rotate_train },
 	{ "func_rotate_entity", SP_func_rotate_entity },
+
+	{ "trigger_heal", SP_trigger_heal },
 
 	{ 0, 0 }
 };

--- a/src/g_spawn.c
+++ b/src/g_spawn.c
@@ -167,6 +167,10 @@ field_t fields[] =
 	{ "rotate", 					FOFS(rotate), 					F_VECTOR },
 	{ "path", 						FOFS(path), 					F_LSTRING },
 	{ "event", 						FOFS(event), 					F_LSTRING },
+
+// Bob
+	{ "waitmin", 					FOFS(waitmin), 						F_FLOAT},
+	{ "waitmin2", 					FOFS(waitmin2), 					F_FLOAT},
 	{ NULL }
 };
 
@@ -243,6 +247,8 @@ void SP_func_plat();
 void SP_func_train();
 void SP_misc_teleporttrain();
 void SP_func_button();
+
+void SP_func_bob();
 
 void SP_trigger_multiple();
 void SP_trigger_once();
@@ -381,6 +387,8 @@ spawn_t spawns[] =
 	{ "func_train", 					SP_func_train },
 	{ "misc_teleporttrain", 			SP_misc_teleporttrain },
 	{ "func_button", 					SP_func_button },
+
+	{ "func_bob", 						SP_func_bob },
 
 	{ "trigger_multiple", 				SP_trigger_multiple },
 	{ "trigger_once", 					SP_trigger_once },

--- a/src/g_spawn.c
+++ b/src/g_spawn.c
@@ -167,6 +167,7 @@ field_t fields[] =
 	{ "rotate", 					FOFS(rotate), 					F_VECTOR },
 	{ "path", 						FOFS(path), 					F_LSTRING },
 	{ "event", 						FOFS(event), 					F_LSTRING },
+	{ "group", 						FOFS(group), 					F_LSTRING },
 
 // Bob
 	{ "waitmin", 					FOFS(waitmin), 						F_FLOAT},

--- a/src/g_spawn.c
+++ b/src/g_spawn.c
@@ -252,6 +252,7 @@ void SP_misc_teleporttrain();
 void SP_func_button();
 
 void SP_func_bob();
+void SP_func_laser();
 
 void SP_trigger_multiple();
 void SP_trigger_once();
@@ -395,6 +396,7 @@ spawn_t spawns[] =
 	{ "func_button", 					SP_func_button },
 
 	{ "func_bob", 						SP_func_bob },
+	{ "func_laser", 					SP_func_laser },
 
 	{ "trigger_multiple", 				SP_trigger_multiple },
 	{ "trigger_once", 					SP_trigger_once },

--- a/src/g_spawn.c
+++ b/src/g_spawn.c
@@ -162,6 +162,11 @@ field_t fields[] =
 
 // Transparent entities in map
 	{ "alpha", 						-1, 								F_FLOAT },
+
+// Rotate
+	{ "rotate", 					FOFS(rotate), 					F_VECTOR },
+	{ "path", 						FOFS(path), 					F_LSTRING },
+	{ "event", 						FOFS(event), 					F_LSTRING },
 	{ NULL }
 };
 
@@ -314,6 +319,15 @@ void SP_i_p_t();
 // Races
 void SP_race_route_start();
 
+// Rotate
+void SP_info_rotate();
+void SP_path_rotate();
+void SP_func_rotate_entity();
+void SP_func_rotate_train();
+void SP_func_movewall();
+void SP_rotate_object();
+void SP_func_rotate_door();
+
 spawn_t spawns[] =
 {
 // info entities don't do anything at all, but provide positional
@@ -455,6 +469,15 @@ spawn_t spawns[] =
 // race routes
 	{ "race_route_start", 				SP_race_route_start },
 	{ "race_route_marker", 				SUB_Null },
+
+// rotate
+	{ "info_rotate",  SP_info_rotate },
+	{ "path_rotate",  SP_path_rotate },
+	{ "rotate_object", SP_rotate_object },
+	{ "func_movewall", SP_func_movewall },
+	{ "func_rotate_door", SP_func_rotate_door },
+	{ "func_rotate_train", SP_func_rotate_train },
+	{ "func_rotate_entity", SP_func_rotate_entity },
 
 	{ 0, 0 }
 };

--- a/src/g_spawn.c
+++ b/src/g_spawn.c
@@ -171,6 +171,9 @@ field_t fields[] =
 // Bob
 	{ "waitmin", 					FOFS(waitmin), 						F_FLOAT},
 	{ "waitmin2", 					FOFS(waitmin2), 					F_FLOAT},
+
+// ambient_general
+	{ "volume", 					FOFS(volume), 						F_FLOAT },
 	{ NULL }
 };
 
@@ -334,6 +337,8 @@ void SP_func_movewall();
 void SP_rotate_object();
 void SP_func_rotate_door();
 
+void SP_ambient_general();
+
 spawn_t spawns[] =
 {
 // info entities don't do anything at all, but provide positional
@@ -371,6 +376,7 @@ spawn_t spawns[] =
 	{ "ambient_light_buzz", 			SP_ambient_light_buzz },
 	{ "ambient_swamp1", 				SP_ambient_swamp1 },
 	{ "ambient_swamp2", 				SP_ambient_swamp2 },
+	{ "ambient_general", 				SP_ambient_general },
 	{ "misc_noisemaker", 				SP_misc_noisemaker },
 	{ "misc_explobox", 					SP_misc_explobox },
 	{ "misc_explobox2", 				SP_misc_explobox2 },

--- a/src/g_syscalls.c
+++ b/src/g_syscalls.c
@@ -492,13 +492,21 @@ void trap_SetExtField_f(gedict_t *ed, const char *fieldname, float val)
 
 int trap_GetExtField_i(gedict_t *ed, const char *fieldname)
 {
-	return syscall(G_GETEXTFIELD, (intptr_t)ed, (intptr_t)fieldname);
+	int ival = -1;
+	if (HAVEEXTENSION(G_GETEXTFIELD))
+	{
+		ival = syscall(G_GETEXTFIELD, (intptr_t)ed, (intptr_t)fieldname);
+	}
+	return ival;
 }
 
 float trap_GetExtField_f(gedict_t *ed, const char *fieldname)
 {
-	fi_t tmp;
-	tmp._int = syscall(G_GETEXTFIELD, (intptr_t)ed, (intptr_t)fieldname);
+	fi_t tmp = { ._float = -1 };
+	if (HAVEEXTENSION(G_GETEXTFIELD))
+	{
+		tmp._int = syscall(G_GETEXTFIELD, (intptr_t)ed, (intptr_t)fieldname);
+	}
 	return tmp._float;
 }
 

--- a/src/hiprot.c
+++ b/src/hiprot.c
@@ -518,7 +518,7 @@ static void rotate_train_next()
 {
 	gedict_t *targ, *current, *goalentity;
 	vec3_t vdestdelta;
-	float len, traveltime, div;
+	float len, traintraveltime, div;
 	char *temp;
 
 	self->state = STATE_NEXT;
@@ -631,7 +631,7 @@ static void rotate_train_next()
 
 		if ((int) current->s.v.spawnflags & MOVETIME)
 		{
-			traveltime = current->speed;
+			traintraveltime = current->speed;
 		}
 		else
 		{
@@ -647,10 +647,10 @@ static void rotate_train_next()
 			}
 
 			// divide by speed to get time to reach dest
-			traveltime = len / self->speed;
+			traintraveltime = len / self->speed;
 		}
 
-		if (traveltime < 0.1)
+		if (traintraveltime < 0.1f)
 		{
 			SetVector(self->s.v.velocity, 0, 0, 0);
 			self->endtime = self->s.v.ltime + 0.1;
@@ -662,7 +662,7 @@ static void rotate_train_next()
 		}
 
 		// qcc won't take vec/float
-		div = 1 / traveltime;
+		div = 1.0f / traintraveltime;
 
 		if ((int) targ->s.v.spawnflags & ANGLES)
 		{
@@ -674,7 +674,7 @@ static void rotate_train_next()
 		}
 
 		// set endtime to trigger a think when dest is reached
-		self->endtime = self->s.v.ltime + traveltime;
+		self->endtime = self->s.v.ltime + traintraveltime;
 
 		// scale the destdelta vector by the time spent traveling to get velocity
 		VectorScale(vdestdelta, div, self->s.v.velocity);

--- a/src/hiprot.c
+++ b/src/hiprot.c
@@ -154,7 +154,7 @@ static void LinkRotateTargets()
 		{
 			ent->rotate_type = OBJECT_MOVEWALL;
 			VectorAdd(ent->s.v.absmin, ent->s.v.absmax, tempvec);
-			VectorScale(tempvec, 0.5, tempvec);
+			VectorScale(tempvec, 0.5f, tempvec);
 
 			VectorSubtract(tempvec, self->s.v.oldorigin, ent->s.v.oldorigin);
 			VectorCopy(ent->s.v.oldorigin, ent->neworigin);
@@ -181,7 +181,7 @@ static void HurtSetDamage(gedict_t *ent, float amount)
 	{
 		ent->s.v.solid = SOLID_TRIGGER;
 	}
-	ent->s.v.nextthink = (func_t) SUB_Null;
+	ent->s.v.nextthink = -1;
 }
 
 static void SetDamageOnTargets(float amount)
@@ -213,9 +213,9 @@ static void SetDamageOnTargets(float amount)
 
 static void SUB_NormalizeAngles(vec3_t v)
 {
-	v[0] = fmod(v[0], 360.0);
-	v[1] = fmod(v[1], 360.0);
-	v[2] = fmod(v[2], 360.0);
+	v[0] = (float) fmod(v[0], 360.0);
+	v[1] = (float) fmod(v[1], 360.0);
+	v[2] = (float) fmod(v[2], 360.0);
 }
 
 static void rotate_entity_think()
@@ -256,7 +256,7 @@ static void rotate_entity_think()
 	VectorAdd(self->s.v.angles, delta, self->s.v.angles);
 	SUB_NormalizeAngles(self->s.v.angles);
 	RotateTargets();
-	self->s.v.nextthink = g_globalvars.time + 0.02;
+	self->s.v.nextthink = g_globalvars.time + 0.02f;
 }
 
 static void rotate_entity_use()
@@ -283,7 +283,7 @@ static void rotate_entity_use()
 	else if (self->state == STATE_INACTIVE)
 	{
 		self->think = (func_t) rotate_entity_think;
-		self->s.v.nextthink = g_globalvars.time + 0.02;
+		self->s.v.nextthink = g_globalvars.time + 0.02f;
 		self->s.v.ltime = g_globalvars.time;
 		if (self->speed)
 		{
@@ -315,7 +315,7 @@ static void rotate_entity_firstthink()
 	{
 		self->state = STATE_ACTIVE;
 		self->think = (func_t) rotate_entity_think;
-		self->s.v.nextthink = g_globalvars.time + 0.02;
+		self->s.v.nextthink = g_globalvars.time + 0.02f;
 		self->s.v.ltime = g_globalvars.time;
 	}
 	else
@@ -355,7 +355,7 @@ void SP_func_rotate_entity()
 	}
 
 	self->think = (func_t) rotate_entity_firstthink;
-	self->s.v.nextthink = g_globalvars.time + 0.1;
+	self->s.v.nextthink = g_globalvars.time + 0.1f;
 	self->s.v.ltime = g_globalvars.time;
 }
 
@@ -442,7 +442,7 @@ static void rotate_train_think()
 
 	RotateTargets();
 
-	self->s.v.nextthink = g_globalvars.time + 0.02;
+	self->s.v.nextthink = g_globalvars.time + 0.02f;
 }
 
 static void rotate_train_use()
@@ -592,7 +592,7 @@ static void rotate_train_next()
 	{
 		// Warp to the next path_corner
 		setorigin( self, PASSVEC3(targ->s.v.origin));
-		self->endtime = self->s.v.ltime + 0.01;
+		self->endtime = self->s.v.ltime + 0.01f;
 		SetTargetOrigin();
 
 		if ((int) targ->s.v.spawnflags & ANGLES)
@@ -614,7 +614,7 @@ static void rotate_train_next()
 		if (VectorCompare(self->finaldest, self->s.v.origin))
 		{
 			SetVector(self->s.v.velocity, 0, 0, 0);
-			self->endtime = self->s.v.ltime + 0.1;
+			self->endtime = self->s.v.ltime + 0.1f;
 
 			self->duration = 1;                        // 1 / duration
 			self->cnt = g_globalvars.time;             // start time
@@ -653,7 +653,7 @@ static void rotate_train_next()
 		if (traintraveltime < 0.1f)
 		{
 			SetVector(self->s.v.velocity, 0, 0, 0);
-			self->endtime = self->s.v.ltime + 0.1;
+			self->endtime = self->s.v.ltime + 0.1f;
 			if ((int) targ->s.v.spawnflags & ANGLES)
 			{
 				VectorCopy(targ->s.v.angles, self->s.v.angles);
@@ -720,7 +720,7 @@ static void rotate_train_find()
 	if (strnull(self->targetname))
 	{
 		// not triggered, so start immediately
-		self->endtime = self->s.v.ltime + 0.1;
+		self->endtime = self->s.v.ltime + 0.1f;
 	}
 	else
 	{
@@ -812,18 +812,18 @@ void SP_func_rotate_train()
 	// start trains on the second frame, to make sure their targets have had
 	// a chance to spawn
 	self->s.v.ltime = g_globalvars.time;
-	self->s.v.nextthink = self->s.v.ltime + 0.1;
-	self->endtime = self->s.v.ltime + 0.1;
+	self->s.v.nextthink = self->s.v.ltime + 0.1f;
+	self->endtime = self->s.v.ltime + 0.1f;
 	self->think = (func_t) rotate_train_think;
 	self->think1 = rotate_train_find;
 	self->state = STATE_FIND;
 
 	self->duration = 1;						   // 1 / duration
-	self->cnt = 0.1;						   // start time
+	self->cnt = 0.1f;						   // start time
 	SetVector(self->dest2, 0, 0, 0);		   // delta
 	VectorCopy(self->s.v.origin, self->dest1); // original position
 
-	self->s.v.flags = (int) self->s.v.flags | FL_ONGROUND;
+	self->s.v.flags = (float)((int) self->s.v.flags | FL_ONGROUND);
 }
 
 //************************************************
@@ -847,12 +847,12 @@ static void movewall_touch()
 	if (self->dmg)
 	{
 		T_Damage (other, self, owner, self->dmg);
-		owner->attack_finished = g_globalvars.time + 0.5;
+		owner->attack_finished = g_globalvars.time + 0.5f;
 	}
 	else if (owner->dmg)
 	{
 		T_Damage (other, self, owner, owner->dmg);
-		owner->attack_finished = g_globalvars.time + 0.5;
+		owner->attack_finished = g_globalvars.time + 0.5f;
 	}
 }
 
@@ -866,7 +866,7 @@ static void movewall_blocked()
 		return;
 	}
 
-	owner->attack_finished = g_globalvars.time + 0.5;
+	owner->attack_finished = g_globalvars.time + 0.5f;
 
 	if (streq(owner->classname, "func_rotate_door"))
 	{
@@ -879,19 +879,19 @@ static void movewall_blocked()
 	if ( self->dmg)
 	{
 		T_Damage (other, self, owner, self->dmg);
-		owner->attack_finished = g_globalvars.time + 0.5;
+		owner->attack_finished = g_globalvars.time + 0.5f;
 	}
 	else if (owner->dmg)
 	{
 		T_Damage (other, self, owner, owner->dmg);
-		owner->attack_finished = g_globalvars.time + 0.5;
+		owner->attack_finished = g_globalvars.time + 0.5f;
 	}
 }
 
 static void movewall_think()
 {
 	self->s.v.ltime = g_globalvars.time;
-	self->s.v.nextthink = g_globalvars.time + 0.02;
+	self->s.v.nextthink = g_globalvars.time + 0.02f;
 }
 
 /*QUAKED func_movewall (0 .5 .8) ? VISIBLE TOUCH NONBLOCKING
@@ -928,7 +928,7 @@ void SP_func_movewall()
 		self->model = NULL;
 	}
 	self->think = (func_t) movewall_think;
-	self->s.v.nextthink = g_globalvars.time + 0.02;
+	self->s.v.nextthink = g_globalvars.time + 0.02f;
 	self->s.v.ltime = g_globalvars.time;
 }
 
@@ -1001,7 +1001,7 @@ static void rotate_door_think()
 		self->think = (func_t) rotate_door_think2;
 	}
 
-	self->s.v.nextthink = g_globalvars.time + 0.01;
+	self->s.v.nextthink = g_globalvars.time + 0.01f;
 }
 
 static void rotate_door_reversedirection()
@@ -1027,10 +1027,10 @@ static void rotate_door_reversedirection()
 	sound(self, CHAN_VOICE, self->noise2, 1, ATTN_NORM);
 
 	VectorSubtract(self->dest, start, self->rotate);
-	VectorScale(self->rotate, 1.0 / self->speed, self->rotate);
+	VectorScale(self->rotate, 1.0f / self->speed, self->rotate);
 
 	self->think = (func_t) rotate_door_think;
-	self->s.v.nextthink = g_globalvars.time + 0.02;
+	self->s.v.nextthink = g_globalvars.time + 0.02f;
 	self->endtime = g_globalvars.time + self->speed - (self->endtime - g_globalvars.time);
 	self->s.v.ltime = g_globalvars.time;
 }
@@ -1090,9 +1090,9 @@ static void rotate_door_use()
 	sound(self, CHAN_VOICE, self->noise2, 1, ATTN_NORM);
 
 	VectorSubtract(self->dest, start, self->rotate);
-	VectorScale(self->rotate, 1.0 / self->speed, self->rotate);
+	VectorScale(self->rotate, 1.0f / self->speed, self->rotate);
 	self->think = (func_t) rotate_door_think;
-	self->s.v.nextthink = g_globalvars.time + 0.01;
+	self->s.v.nextthink = g_globalvars.time + 0.01f;
 	self->endtime = g_globalvars.time + self->speed;
 	self->s.v.ltime = g_globalvars.time;
 }

--- a/src/hiprot.c
+++ b/src/hiprot.c
@@ -1,0 +1,1185 @@
+// This code is a line by line port of the re-release hiprot QuakeC code.
+// https://github.com/id-Software/quake-rerelease-qc/blob/main/quakec_hipnotic/hiprot.qc
+
+#include "g_local.h"
+
+#define STATE_ACTIVE      0
+#define STATE_INACTIVE    1
+#define STATE_SPEEDINGUP  2
+#define STATE_SLOWINGDOWN 3
+
+#define STATE_CLOSED   4
+#define STATE_OPEN     5
+#define STATE_OPENING  6
+#define STATE_CLOSING  7
+
+#define STATE_WAIT 0
+#define STATE_MOVE 1
+#define STATE_STOP 2
+#define STATE_FIND 3
+#define STATE_NEXT 4
+
+#define OBJECT_ROTATE    0
+#define OBJECT_MOVEWALL  1
+#define OBJECT_SETORIGIN 2
+
+#define TOGGLE   1
+#define START_ON 2
+
+#define ROTATION    1
+#define ANGLES      2
+#define STOP        4
+#define NO_ROTATE   8
+#define DAMAGE     16
+#define MOVETIME   32
+#define SET_DAMAGE 64
+
+#define VISIBLE     1
+#define TOUCH       2
+#define NONBLOCKING 4
+
+#define STAYOPEN 1
+
+/*QUAKED info_rotate (0 0.5 0) (-4 -4 -4) (4 4 4)
+Used as the point of rotation for rotatable objects.
+*/
+void SP_info_rotate()
+{
+	// remove self after a little while, to make sure that entities that
+	// have targeted it have had a chance to spawn
+	self->s.v.nextthink = g_globalvars.time + 2;
+	self->think = (func_t) SUB_Remove;
+}
+
+static void RotateTargets()
+{
+	gedict_t *ent;
+	vec3_t vx, vy, vz, org;
+
+	trap_makevectors(self->s.v.angles);
+
+	ent = find(world, FOFS(targetname), self->target);
+	while (ent)
+	{
+		VectorCopy(ent->s.v.oldorigin, org);
+		VectorScale(g_globalvars.v_forward, org[0], vx);
+		VectorScale(g_globalvars.v_right, org[1], vy);
+		VectorScale(vy, -1, vy);
+		VectorScale(g_globalvars.v_up, org[2], vz);
+		VectorAdd(vx, vy, ent->neworigin);
+		VectorAdd(ent->neworigin, vz, ent->neworigin);
+
+		if (ent->rotate_type == OBJECT_SETORIGIN)
+		{
+			VectorAdd(ent->neworigin, self->s.v.origin, org);
+			setorigin(ent, PASSVEC3(org));
+		}
+		else if ( ent->rotate_type == OBJECT_ROTATE)
+		{
+			VectorCopy(self->s.v.angles, ent->s.v.angles);
+			VectorAdd(ent->neworigin, self->s.v.origin, org);
+			setorigin(ent, PASSVEC3(org));
+		}
+		else
+		{
+			VectorSubtract(self->s.v.origin, self->s.v.oldorigin, org);
+			VectorAdd(org, ent->neworigin, org);
+			VectorSubtract(org, ent->s.v.oldorigin, ent->neworigin);
+
+			VectorSubtract(ent->neworigin, ent->s.v.origin, org);
+			VectorScale(org, 25, ent->s.v.velocity);
+		}
+		ent = find(ent, FOFS(targetname), self->target);
+	}
+}
+
+static void RotateTargetsFinal()
+{
+	gedict_t *ent;
+
+	ent = find(world, FOFS(targetname), self->target);
+	while (ent)
+	{
+		SetVector(ent->s.v.velocity, 0, 0, 0);
+		if (ent->rotate_type == OBJECT_ROTATE)
+		{
+			VectorCopy(self->s.v.angles, ent->s.v.angles);
+		}
+		ent = find(ent, FOFS(targetname), self->target);
+	}
+}
+
+static void SetTargetOrigin()
+{
+	gedict_t *ent;
+	vec3_t org;
+
+	ent = find(world, FOFS(targetname), self->target);
+	while (ent)
+	{
+		if (ent->rotate_type == OBJECT_MOVEWALL)
+		{
+			VectorSubtract(self->s.v.origin, self->s.v.oldorigin, org);
+			VectorAdd(org, ent->neworigin, org);
+			VectorSubtract(org, ent->s.v.oldorigin, org);
+			setorigin(ent, PASSVEC3(org));
+		}
+		else
+		{
+			VectorAdd(ent->neworigin, self->s.v.origin, org);
+			setorigin(ent, PASSVEC3(org));
+		}
+		ent = find(ent, FOFS(targetname), self->target);
+	}
+}
+
+static void LinkRotateTargets()
+{
+	gedict_t *ent;
+	vec3_t tempvec;
+
+	VectorCopy(self->s.v.origin, self->s.v.oldorigin);
+
+	ent = find(world, FOFS(targetname), self->target);
+	while (ent)
+	{
+		if (streq(ent->classname, "rotate_object"))
+		{
+			ent->rotate_type = OBJECT_ROTATE;
+			VectorSubtract(ent->s.v.origin, self->s.v.oldorigin, ent->s.v.oldorigin);
+			VectorSubtract(ent->s.v.origin, self->s.v.oldorigin, ent->neworigin);
+			ent->s.v.owner = EDICT_TO_PROG(self);
+		}
+		else if (streq(ent->classname, "func_movewall"))
+		{
+			ent->rotate_type = OBJECT_MOVEWALL;
+			VectorAdd(ent->s.v.absmin, ent->s.v.absmax, tempvec);
+			VectorScale(tempvec, 0.5, tempvec);
+
+			VectorSubtract(tempvec, self->s.v.oldorigin, ent->s.v.oldorigin);
+			VectorCopy(ent->s.v.oldorigin, ent->neworigin);
+			ent->s.v.owner = EDICT_TO_PROG(self);
+		}
+		else
+		{
+			ent->rotate_type = OBJECT_SETORIGIN;
+			VectorSubtract(ent->s.v.origin, self->s.v.oldorigin, ent->s.v.oldorigin);
+			VectorSubtract(ent->s.v.origin, self->s.v.oldorigin, ent->neworigin);
+		}
+		ent = find(ent, FOFS(targetname), self->target);
+	}
+}
+
+static void HurtSetDamage(gedict_t *ent, float amount)
+{
+	ent->dmg = amount;
+	if (!amount)
+	{
+		ent->s.v.solid = SOLID_NOT;
+	}
+	else
+	{
+		ent->s.v.solid = SOLID_TRIGGER;
+	}
+	ent->s.v.nextthink = (func_t) SUB_Null;
+}
+
+static void SetDamageOnTargets(float amount)
+{
+	gedict_t *ent;
+
+	ent = find(world, FOFS(targetname), self->target);
+	while (ent)
+	{
+		if (streq(ent->classname, "trigger_hurt"))
+		{
+			HurtSetDamage(ent, amount);
+		}
+		else if (streq(ent->classname, "func_movewall"))
+		{
+			ent->dmg = amount;
+		}
+
+		ent = find(ent, FOFS(targetname), self->target);
+	}
+}
+
+
+//************************************************
+//
+// Simple continual rotatation
+//
+//************************************************
+
+static void SUB_NormalizeAngles(vec3_t v)
+{
+	v[0] = fmod(v[0], 360.0);
+	v[1] = fmod(v[1], 360.0);
+	v[2] = fmod(v[2], 360.0);
+}
+
+static void rotate_entity_think()
+{
+	vec3_t delta;
+	float t;
+
+	t = g_globalvars.time - self->s.v.ltime;
+	self->s.v.ltime = g_globalvars.time;
+
+	if (self->state == STATE_SPEEDINGUP)
+	{
+		self->count = self->count + self->cnt * t;
+		if (self->count > 1)
+		{
+			self->count = 1;
+		}
+
+		// get rate of rotation
+		t = t * self->count;
+	}
+	else if (self->state == STATE_SLOWINGDOWN)
+	{
+		self->count = self->count - self->cnt * t;
+		if (self->count < 0)
+		{
+			RotateTargetsFinal();
+			self->state = STATE_INACTIVE;
+			self->think = (func_t) SUB_Null;
+			return;
+		}
+
+		// get rate of rotation
+		t = t * self->count;
+	}
+
+	VectorScale(self->rotate, t, delta);
+	VectorAdd(self->s.v.angles, delta, self->s.v.angles);
+	SUB_NormalizeAngles(self->s.v.angles);
+	RotateTargets();
+	self->s.v.nextthink = g_globalvars.time + 0.02;
+}
+
+static void rotate_entity_use()
+{
+	// change to alternate textures
+	self->s.v.frame = 1 - self->s.v.frame;
+
+	if (self->state == STATE_ACTIVE)
+	{
+		if ((int) self->s.v.spawnflags & TOGGLE)
+		{
+			if (self->speed)
+			{
+				self->count = 1;
+				self->state = STATE_SLOWINGDOWN;
+			}
+			else
+			{
+				self->state = STATE_INACTIVE;
+				self->think = (func_t) SUB_Null;
+			}
+		}
+	}
+	else if (self->state == STATE_INACTIVE)
+	{
+		self->think = (func_t) rotate_entity_think;
+		self->s.v.nextthink = g_globalvars.time + 0.02;
+		self->s.v.ltime = g_globalvars.time;
+		if (self->speed)
+		{
+			self->count = 0;
+			self->state = STATE_SPEEDINGUP;
+		}
+		else
+		{
+			self->state = STATE_ACTIVE;
+		}
+	}
+	else if (self->state == STATE_SPEEDINGUP)
+	{
+		if ((int) self->s.v.spawnflags & TOGGLE)
+		{
+			self->state = STATE_SLOWINGDOWN;
+		}
+	}
+	else
+	{
+		self->state = STATE_SPEEDINGUP;
+	}
+}
+
+static void rotate_entity_firstthink()
+{
+	LinkRotateTargets();
+	if ((int) self->s.v.spawnflags & START_ON )
+	{
+		self->state = STATE_ACTIVE;
+		self->think = (func_t) rotate_entity_think;
+		self->s.v.nextthink = g_globalvars.time + 0.02;
+		self->s.v.ltime = g_globalvars.time;
+	}
+	else
+	{
+		self->state = STATE_INACTIVE;
+		self->think = (func_t) SUB_Null;
+	}
+	self->use = (func_t) rotate_entity_use;
+}
+
+/*QUAKED func_rotate_entity (0 .5 .8) (-8 -8 -8) (8 8 8) TOGGLE START_ON
+Creates an entity that continually rotates.	 Can be toggled on and
+off if targeted.
+
+TOGGLE = allows the rotation to be toggled on/off
+
+START_ON = wether the entity is spinning when spawned.	If TOGGLE is 0, entity can be turned on, but not off.
+
+If "deathtype" is set with a string, this is the message that will appear when a player is killed by the train.
+
+"rotate" is the rate to rotate.
+"target" is the center of rotation.
+"speed"	 is how long the entity takes to go from standing still to full speed and vice-versa.
+*/
+
+void SP_func_rotate_entity()
+{
+	self->s.v.solid = SOLID_NOT;
+	self->s.v.movetype = MOVETYPE_NONE;
+
+	setmodel(self, self->model);
+	setsize(self, PASSVEC3(self->s.v.mins), PASSVEC3(self->s.v.maxs));
+
+	if (self->speed != 0 )
+	{
+		self->cnt = 1 / self->speed;
+	}
+
+	self->think = (func_t) rotate_entity_firstthink;
+	self->s.v.nextthink = g_globalvars.time + 0.1;
+	self->s.v.ltime = g_globalvars.time;
+}
+
+//************************************************
+//
+// Train with rotation functionality
+//
+//************************************************
+
+/*QUAKED path_rotate (0.5 0.3 0) (-8 -8 -8) (8 8 8) ROTATION ANGLES STOP NO_ROTATE DAMAGE MOVETIME SET_DAMAGE
+ Path for rotate_train.
+
+ ROTATION tells train to rotate at rate specified by "rotate".	Use '0 0 0' to stop rotation.
+
+ ANGLES tells train to rotate to the angles specified by "angles" while traveling to this path_rotate.	Use values < 0 or > 360 to guarantee that it turns in a certain direction.	Having this flag set automatically clears any rotation.
+
+ STOP tells the train to stop and wait to be retriggered.
+
+ NO_ROTATE tells the train to stop rotating when waiting to be triggered.
+
+ DAMAGE tells the train to cause damage based on "dmg".
+
+ MOVETIME tells the train to interpret "speed" as the length of time to take moving from one corner to another.
+
+ SET_DAMAGE tells the train to set all targets damage to "dmg"
+
+ "noise" contains the name of the sound to play when train stops.
+ "noise1" contains the name of the sound to play when train moves.
+ "event" is a target to trigger when train arrives at path_rotate.
+*/
+void SP_path_rotate()
+{
+	if (self->noise)
+	{
+		trap_precache_sound(self->noise);
+	}
+	if (self->noise1)
+	{
+		trap_precache_sound(self->noise1);
+	}
+}
+
+
+static void rotate_train_next();
+static void rotate_train_find();
+
+static void rotate_train_think()
+{
+	float t, timeelapsed;
+	vec3_t delta;
+
+	t = g_globalvars.time - self->s.v.ltime;
+	self->s.v.ltime = g_globalvars.time;
+
+	if (self->endtime && (g_globalvars.time >= self->endtime))
+	{
+		self->endtime = 0;
+		if (self->state == STATE_MOVE)
+		{
+			setorigin(self, PASSVEC3(self->finaldest));
+			SetVector(self->s.v.velocity, 0, 0, 0);
+		}
+
+		if (self->think1)
+		{
+			self->think1();
+		}
+	}
+	else
+	{
+		timeelapsed = (g_globalvars.time - self->cnt) * self->duration;
+		if (timeelapsed > 1)
+		{
+			timeelapsed = 1;
+		}
+		VectorScale(self->dest2, timeelapsed, delta);
+		VectorAdd(self->dest1, delta, delta);
+		setorigin(self, PASSVEC3(delta));
+	}
+
+	VectorScale(self->rotate, t, delta);
+	VectorAdd(self->s.v.angles, delta, self->s.v.angles);
+	SUB_NormalizeAngles(self->s.v.angles);
+
+	RotateTargets();
+
+	self->s.v.nextthink = g_globalvars.time + 0.02;
+}
+
+static void rotate_train_use()
+{
+	if (self->think1 != rotate_train_find)
+	{
+		if (VectorLength(self->s.v.velocity))
+		{
+			return; // already activated
+		}
+		if (self->think1)
+		{
+			self->think1();
+		}
+	}
+}
+
+static void rotate_train_wait()
+{
+	gedict_t *goalentity = PROG_TO_EDICT(self->s.v.goalentity);
+	self->state = STATE_WAIT;
+
+	if (!strnull(goalentity->noise))
+	{
+		sound(self, CHAN_VOICE, goalentity->noise, 1, ATTN_NORM);
+	}
+	else
+	{
+		sound(self, CHAN_VOICE, self->noise, 1, ATTN_NORM);
+	}
+	if ((int) goalentity->s.v.spawnflags & ANGLES)
+	{
+		SetVector(self->rotate, 0, 0, 0);
+		VectorCopy(self->finalangle, self->s.v.angles);
+	}
+	if ((int) goalentity->s.v.spawnflags & NO_ROTATE)
+	{
+		SetVector(self->rotate, 0, 0, 0);
+	}
+	self->endtime = self->s.v.ltime + goalentity->wait;
+	self->think1 = rotate_train_next;
+}
+
+static void rotate_train_stop()
+{
+	gedict_t *goalentity = PROG_TO_EDICT(self->s.v.goalentity);
+
+	self->state = STATE_STOP;
+
+	if (!strnull(goalentity->noise))
+	{
+		sound(self, CHAN_VOICE, goalentity->noise, 1, ATTN_NORM);
+	}
+	else
+	{
+		sound(self, CHAN_VOICE, self->noise, 1, ATTN_NORM);
+	}
+	if ((int) goalentity->s.v.spawnflags & ANGLES)
+	{
+		SetVector(self->rotate, 0, 0, 0);
+		VectorCopy(self->finalangle, self->s.v.angles);
+	}
+	if ((int) goalentity->s.v.spawnflags & NO_ROTATE)
+	{
+		SetVector(self->rotate, 0, 0, 0);
+	}
+
+	self->dmg = 0;
+	self->think1 = rotate_train_next;
+}
+
+static void rotate_train_next()
+{
+	gedict_t *targ, *current, *goalentity;
+	vec3_t vdestdelta;
+	float len, traveltime, div;
+	char *temp;
+
+	self->state = STATE_NEXT;
+
+	goalentity = PROG_TO_EDICT(self->s.v.goalentity);
+	current = goalentity;
+	targ = find (world, FOFS(targetname), self->path);
+	if (!streq(targ->classname, "path_rotate"))
+	{
+		G_Error( "Next target is not path_rotate");
+	}
+
+	if (goalentity->noise1)
+	{
+		self->noise1 = goalentity->noise1;
+	}
+
+	sound(self, CHAN_VOICE, self->noise1, 1, ATTN_NORM);
+
+	self->s.v.goalentity = EDICT_TO_PROG(targ);
+	self->path = targ->target;
+	if (strnull(self->path))
+		G_Error("rotate_train_next: no next target");
+
+	if ((int) targ->s.v.spawnflags & STOP)
+	{
+		self->think1 = rotate_train_stop;
+	}
+	else if (targ->wait)
+	{
+		self->think1 = rotate_train_wait;
+	}
+	else
+	{
+		self->think1 = rotate_train_next;
+	}
+
+	if (current->event)
+	{
+		// Trigger any events that should happen at the corner.
+		temp = self->target;
+		self->target = current->event;
+		self->message = current->message;
+		SUB_UseTargets();
+		self->target = temp;
+		self->message = NULL;
+	}
+
+	if ((int) current->s.v.spawnflags & ANGLES)
+	{
+		SetVector(self->rotate, 0, 0, 0);
+		VectorCopy(self->finalangle, self->s.v.angles);
+	}
+
+	if ((int) current->s.v.spawnflags & ROTATION)
+	{
+		VectorCopy(current->rotate, self->rotate);
+	}
+
+	if ((int) current->s.v.spawnflags & DAMAGE)
+	{
+		self->dmg = current->dmg;
+	}
+
+	if ((int) current->s.v.spawnflags & SET_DAMAGE)
+	{
+		SetDamageOnTargets( current->dmg);
+	}
+
+	if (current->speed == -1 )
+	{
+		// Warp to the next path_corner
+		setorigin( self, PASSVEC3(targ->s.v.origin));
+		self->endtime = self->s.v.ltime + 0.01;
+		SetTargetOrigin();
+
+		if ((int) targ->s.v.spawnflags & ANGLES)
+		{
+			VectorCopy(targ->s.v.angles, self->s.v.angles);
+		}
+
+		self->duration = 1;                        // 1 / duration
+		self->cnt = g_globalvars.time;             // start time
+		SetVector(self->dest2, 0, 0, 0);           // delta
+		VectorCopy(self->s.v.origin, self->dest1); // original position
+		VectorCopy(self->s.v.origin, self->finaldest);
+	}
+	else
+	{
+		self->state = STATE_MOVE;
+
+		VectorCopy(targ->s.v.origin, self->finaldest);
+		if (VectorCompare(self->finaldest, self->s.v.origin))
+		{
+			SetVector(self->s.v.velocity, 0, 0, 0);
+			self->endtime = self->s.v.ltime + 0.1;
+
+			self->duration = 1;                        // 1 / duration
+			self->cnt = g_globalvars.time;             // start time
+			SetVector(self->dest2, 0, 0, 0);           // delta
+			VectorCopy(self->s.v.origin, self->dest1); // original position
+			VectorCopy(self->s.v.origin, self->finaldest);
+			return;
+		}
+		// set destdelta to the vector needed to move
+		VectorSubtract(self->finaldest, self->s.v.origin, vdestdelta);
+
+		// calculate length of vector
+		len = vlen (vdestdelta);
+
+		if ((int) current->s.v.spawnflags & MOVETIME)
+		{
+			traveltime = current->speed;
+		}
+		else
+		{
+			// check if there's a speed change
+			if (current->speed > 0)
+			{
+				self->speed = current->speed;
+			}
+
+			if (!self->speed)
+			{
+				G_Error("No speed is defined!");
+			}
+
+			// divide by speed to get time to reach dest
+			traveltime = len / self->speed;
+		}
+
+		if (traveltime < 0.1)
+		{
+			SetVector(self->s.v.velocity, 0, 0, 0);
+			self->endtime = self->s.v.ltime + 0.1;
+			if ((int) targ->s.v.spawnflags & ANGLES)
+			{
+				VectorCopy(targ->s.v.angles, self->s.v.angles);
+			}
+			return;
+		}
+
+		// qcc won't take vec/float
+		div = 1 / traveltime;
+
+		if ((int) targ->s.v.spawnflags & ANGLES)
+		{
+			VectorCopy(targ->s.v.angles, self->finalangle);
+			SUB_NormalizeAngles(self->finalangle);
+
+			VectorSubtract(targ->s.v.angles, self->s.v.angles, self->rotate);
+			VectorScale(self->rotate, div, self->rotate);
+		}
+
+		// set endtime to trigger a think when dest is reached
+		self->endtime = self->s.v.ltime + traveltime;
+
+		// scale the destdelta vector by the time spent traveling to get velocity
+		VectorScale(vdestdelta, div, self->s.v.velocity);
+
+		self->duration = div;                      // 1 / duration
+		self->cnt = g_globalvars.time;             // start time
+		VectorCopy(vdestdelta, self->dest2);       // delta
+		VectorCopy(self->s.v.origin, self->dest1); // original position
+	}
+}
+
+static void rotate_train_find()
+{
+	gedict_t *targ;
+
+	self->state = STATE_FIND;
+
+	LinkRotateTargets();
+
+	// the first target is the point of rotation.
+	// the second target is the path.
+	targ = find (world, FOFS(targetname), self->path);
+	if (!streq(targ->classname, "path_rotate"))
+	{
+		G_Error("Next target is not path_rotate");
+	}
+
+	// Save the current entity
+	self->s.v.goalentity = EDICT_TO_PROG(targ);
+
+	if ((int) targ->s.v.spawnflags & ANGLES)
+	{
+		VectorCopy(targ->s.v.angles, self->s.v.angles);
+		SUB_NormalizeAngles(targ->s.v.angles);
+		VectorCopy(targ->s.v.angles, self->finalangle);
+	}
+
+	self->path = targ->target;
+	setorigin (self, PASSVEC3(targ->s.v.origin));
+	SetTargetOrigin();
+	RotateTargetsFinal();
+	self->think1 = rotate_train_next;
+	if (strnull(self->targetname))
+	{
+		// not triggered, so start immediately
+		self->endtime = self->s.v.ltime + 0.1;
+	}
+	else
+	{
+		self->endtime = 0;
+	}
+
+	self->duration = 1;                        // 1 / duration
+	self->cnt = g_globalvars.time;             // start time
+	SetVector(self->dest2, 0, 0, 0);           // delta
+	VectorCopy(self->s.v.origin, self->dest1); // original position
+}
+
+/*QUAKED func_rotate_train (0 .5 .8) (-8 -8 -8) (8 8 8)
+In path_rotate, set speed to be the new speed of the train after it reaches
+the path change.  If speed is -1, the train will warp directly to the next
+path change after the specified wait time.  If MOVETIME is set on the
+path_rotate, the train to interprets "speed" as the length of time to
+take moving from one corner to another.
+
+"noise" contains the name of the sound to play when train stops.
+"noise1" contains the name of the sound to play when train moves.
+Both "noise" and "noise1" defaults depend upon "sounds" variable and
+can be overridden by the "noise" and "noise1" variable in path_rotate.
+
+Also in path_rotate, if STOP is set, the train will wait until it is
+retriggered before moving on to the next goal.
+
+Trains are moving platforms that players can ride.
+"path" specifies the first path_rotate and is the starting position.
+If the train is the target of a button or trigger, it will not begin moving until activated.
+The func_rotate_train entity is the center of rotation of all objects targeted by it.
+
+If "deathtype" is set with a string, this is the message that will appear when a player is killed by the train.
+
+speed	default 100
+dmg		 default  0
+sounds
+1) ratchet metal
+*/
+
+void SP_func_rotate_train()
+{
+	if (!self->speed)
+	{
+		self->speed = 100;
+	}
+
+	if (!self->target)
+	{
+		G_Error ("rotate_train without a target");
+	}
+
+	if (!self->noise)
+	{
+		if (self->s.v.sounds == 0)
+		{
+			self->noise = ("misc/null.wav");
+		}
+
+		if (self->s.v.sounds == 1)
+		{
+			self->noise = ("plats/train2.wav");
+		}
+	}
+	if (!self->noise1)
+	{
+		if (self->s.v.sounds == 0)
+		{
+			self->noise1 = ("misc/null.wav");
+		}
+		if (self->s.v.sounds == 1)
+		{
+			self->noise1 = ("plats/train1.wav");
+		}
+	}
+
+	trap_precache_sound( self->noise );
+	trap_precache_sound( self->noise1 );
+
+	self->cnt = 1;
+	self->s.v.solid	 = SOLID_NOT;
+	self->s.v.movetype = MOVETYPE_STEP;
+	self->use = (func_t) rotate_train_use;
+
+	setmodel (self, self->model);
+	setsize (self, PASSVEC3(self->s.v.mins), PASSVEC3(self->s.v.maxs));
+	setorigin (self, PASSVEC3(self->s.v.origin));
+
+	// start trains on the second frame, to make sure their targets have had
+	// a chance to spawn
+	self->s.v.ltime = g_globalvars.time;
+	self->s.v.nextthink = self->s.v.ltime + 0.1;
+	self->endtime = self->s.v.ltime + 0.1;
+	self->think = (func_t) rotate_train_think;
+	self->think1 = rotate_train_find;
+	self->state = STATE_FIND;
+
+	self->duration = 1;						   // 1 / duration
+	self->cnt = 0.1;						   // start time
+	SetVector(self->dest2, 0, 0, 0);		   // delta
+	VectorCopy(self->s.v.origin, self->dest1); // original position
+
+	self->s.v.flags = (int) self->s.v.flags | FL_ONGROUND;
+}
+
+//************************************************
+//
+// Moving clip walls
+//
+//************************************************
+
+static void rotate_door_reversedirection();
+static void rotate_door_group_reversedirection();
+
+static void movewall_touch()
+{
+	gedict_t *owner = PROG_TO_EDICT(self->s.v.owner);
+
+	if (g_globalvars.time < owner->attack_finished)
+	{
+		return;
+	}
+
+	if (self->dmg)
+	{
+		T_Damage (other, self, owner, self->dmg);
+		owner->attack_finished = g_globalvars.time + 0.5;
+	}
+	else if (owner->dmg)
+	{
+		T_Damage (other, self, owner, owner->dmg);
+		owner->attack_finished = g_globalvars.time + 0.5;
+	}
+}
+
+static void movewall_blocked()
+{
+	gedict_t *owner = PROG_TO_EDICT(self->s.v.owner);
+	gedict_t *temp;
+
+	if (g_globalvars.time < owner->attack_finished)
+	{
+		return;
+	}
+
+	owner->attack_finished = g_globalvars.time + 0.5;
+
+	if (streq(owner->classname, "func_rotate_door"))
+	{
+		temp = self;
+		self = owner;
+		rotate_door_group_reversedirection();
+		self = temp;
+	}
+
+	if ( self->dmg)
+	{
+		T_Damage (other, self, owner, self->dmg);
+		owner->attack_finished = g_globalvars.time + 0.5;
+	}
+	else if (owner->dmg)
+	{
+		T_Damage (other, self, owner, owner->dmg);
+		owner->attack_finished = g_globalvars.time + 0.5;
+	}
+}
+
+static void movewall_think()
+{
+	self->s.v.ltime = g_globalvars.time;
+	self->s.v.nextthink = g_globalvars.time + 0.02;
+}
+
+/*QUAKED func_movewall (0 .5 .8) ? VISIBLE TOUCH NONBLOCKING
+Used to emulate collision on rotating objects.
+
+VISIBLE causes brush to be displayed.
+
+TOUCH specifies whether to cause damage when touched by player.
+
+NONBLOCKING makes the brush non-solid.	This is useless if VISIBLE is set.
+
+"dmg" specifies the damage to cause when touched or blocked.
+*/
+void SP_func_movewall()
+{
+	SetVector(self->s.v.angles, 0, 0, 0);
+	self->s.v.movetype = MOVETYPE_PUSH;
+	if ((int) self->s.v.spawnflags & NONBLOCKING)
+	{
+		self->s.v.solid = SOLID_NOT;
+	}
+	else
+	{
+		self->s.v.solid = SOLID_BSP;
+		self->blocked = (func_t) movewall_blocked;
+	}
+	if ((int) self->s.v.spawnflags & TOUCH)
+	{
+		self->touch = (func_t) movewall_touch;
+	}
+	setmodel(self, self->model);
+	if (!((int) self->s.v.spawnflags & VISIBLE))
+	{
+		self->model = NULL;
+	}
+	self->think = (func_t) movewall_think;
+	self->s.v.nextthink = g_globalvars.time + 0.02;
+	self->s.v.ltime = g_globalvars.time;
+}
+
+/*QUAKED rotate_object (0 .5 .8) ?
+This defines an object to be rotated.  Used as the target of func_rotate_door.
+*/
+void SP_rotate_object()
+{
+	self->classname = "rotate_object";
+	self->s.v.solid = SOLID_NOT;
+	self->s.v.movetype = MOVETYPE_NONE;
+	setmodel(self, self->model);
+	setsize(self, PASSVEC3(self->s.v.mins), PASSVEC3(self->s.v.maxs));
+	self->think = (func_t) SUB_Null;
+};
+
+//************************************************
+//
+// Rotating doors
+//
+//************************************************
+
+static void rotate_door_think2()
+{
+	self->s.v.ltime = g_globalvars.time;
+
+	// change to alternate textures
+	self->s.v.frame = 1 - self->s.v.frame;
+
+	VectorCopy(self->dest, self->s.v.angles);
+
+	if (self->state == STATE_OPENING)
+	{
+		self->state = STATE_OPEN;
+	}
+	else
+	{
+		if ((int) self->s.v.spawnflags & STAYOPEN )
+		{
+			rotate_door_group_reversedirection();
+			return;
+		}
+		self->state = STATE_CLOSED;
+	}
+
+	sound(self, CHAN_VOICE, self->noise3, 1, ATTN_NORM);
+	self->think = (func_t) SUB_Null;
+
+	RotateTargetsFinal();
+}
+
+static void rotate_door_think()
+{
+	float t;
+	vec3_t delta;
+
+	t = g_globalvars.time - self->s.v.ltime;
+	self->s.v.ltime = g_globalvars.time;
+
+	if (g_globalvars.time < self->endtime )
+	{
+		VectorScale(self->rotate, t, delta);
+		VectorAdd(self->s.v.angles, delta, self->s.v.angles);
+		RotateTargets();
+	}
+	else
+	{
+		VectorCopy(self->dest, self->s.v.angles);
+		RotateTargets();
+		self->think = (func_t) rotate_door_think2;
+	}
+
+	self->s.v.nextthink = g_globalvars.time + 0.01;
+}
+
+static void rotate_door_reversedirection()
+{
+	vec3_t start;
+
+   // change to alternate textures
+	self->s.v.frame = 1 - self->s.v.frame;
+
+	if (self->state == STATE_CLOSING)
+	{
+		VectorCopy(self->dest1, start);
+		VectorCopy(self->dest2, self->dest);
+		self->state = STATE_OPENING;
+	}
+	else
+	{
+		VectorCopy(self->dest2, start);
+		VectorCopy(self->dest1, self->dest);
+		self->state = STATE_CLOSING;
+	}
+
+	sound(self, CHAN_VOICE, self->noise2, 1, ATTN_NORM);
+
+	VectorSubtract(self->dest, start, self->rotate);
+	VectorScale(self->rotate, 1.0 / self->speed, self->rotate);
+
+	self->think = (func_t) rotate_door_think;
+	self->s.v.nextthink = g_globalvars.time + 0.02;
+	self->endtime = g_globalvars.time + self->speed - (self->endtime - g_globalvars.time);
+	self->s.v.ltime = g_globalvars.time;
+}
+
+static void rotate_door_group_reversedirection()
+{
+	char *name;
+
+	// tell all associated rotaters to reverse direction
+	if (self->group)
+	{
+		name = self->group;
+		self = find(world, FOFS(group), name);
+		while (self)
+		{
+			rotate_door_reversedirection();
+			self = find(self, FOFS(group), name);
+		}
+	}
+	else
+	{
+		rotate_door_reversedirection();
+	}
+}
+
+static void rotate_door_use()
+{
+	vec3_t start;
+
+	if ((self->state != STATE_OPEN) && (self->state != STATE_CLOSED))
+	{
+		return;
+	}
+
+	if (!self->cnt)
+	{
+		self->cnt = 1;
+		LinkRotateTargets();
+	}
+
+	// change to alternate textures
+	self->s.v.frame = 1 - self->s.v.frame;
+
+	if (self->state == STATE_CLOSED)
+	{
+		VectorCopy(self->dest1, start);
+		VectorCopy(self->dest2, self->dest);
+		self->state = STATE_OPENING;
+	}
+	else
+	{
+		VectorCopy(self->dest2, start);
+		VectorCopy(self->dest1, self->dest);
+		self->state = STATE_CLOSING;
+	}
+
+	sound(self, CHAN_VOICE, self->noise2, 1, ATTN_NORM);
+
+	VectorSubtract(self->dest, start, self->rotate);
+	VectorScale(self->rotate, 1.0 / self->speed, self->rotate);
+	self->think = (func_t) rotate_door_think;
+	self->s.v.nextthink = g_globalvars.time + 0.01;
+	self->endtime = g_globalvars.time + self->speed;
+	self->s.v.ltime = g_globalvars.time;
+}
+
+
+/*QUAKED func_rotate_door (0 .5 .8) (-8 -8 -8) (8 8 8) STAYOPEN
+Creates a door that rotates between two positions around a point of
+rotation each time it's triggered.
+
+STAYOPEN tells the door to reopen after closing.  This prevents a trigger-
+once door from closing again when it's blocked.
+
+"dmg" specifies the damage to cause when blocked.  Defaults to 2.  Negative numbers indicate no damage.
+"speed" specifies how the time it takes to rotate
+
+"sounds"
+1) medieval (default)
+2) metal
+3) base
+*/
+
+void SP_func_rotate_door()
+{
+	if (strnull(self->target))
+	{
+		G_Error("rotate_door without target.");
+	}
+
+	SetVector(self->dest1, 0, 0, 0);
+	VectorCopy(self->s.v.angles, self->dest2);
+	VectorCopy(self->dest1, self->s.v.angles);
+
+	// default to 2 seconds
+	if (!self->speed)
+	{
+		self->speed = 2;
+	}
+
+	self->cnt = 0;
+
+	if (!self->dmg)
+	{
+		self->dmg = 2;
+	}
+	else if (self->dmg < 0)
+	{
+		self->dmg = 0;
+	}
+
+	if (self->s.v.sounds == 0)
+	{
+		self->s.v.sounds = 1;
+	}
+
+	if (self->s.v.sounds == 1)
+	{
+		trap_precache_sound("doors/latch2.wav");
+		trap_precache_sound("doors/winch2.wav");
+		trap_precache_sound("doors/drclos4.wav");
+		self->noise1 = "doors/latch2.wav";
+		self->noise2 = "doors/winch2.wav";
+		self->noise3 = "doors/drclos4.wav";
+	}
+	if (self->s.v.sounds == 2)
+	{
+		trap_precache_sound("doors/airdoor1.wav");
+		trap_precache_sound("doors/airdoor2.wav");
+		self->noise2 = "doors/airdoor1.wav";
+		self->noise1 = "doors/airdoor2.wav";
+		self->noise3 = "doors/airdoor2.wav";
+	}
+	if (self->s.v.sounds == 3)
+	{
+		trap_precache_sound("doors/basesec1.wav");
+		trap_precache_sound("doors/basesec2.wav");
+		self->noise2 = "doors/basesec1.wav";
+		self->noise1 = "doors/basesec2.wav";
+		self->noise3 = "doors/basesec2.wav";
+	}
+
+	self->s.v.solid = SOLID_NOT;
+	self->s.v.movetype = MOVETYPE_NONE;
+	setmodel(self, self->model);
+	setsize(self, PASSVEC3(self->s.v.mins), PASSVEC3(self->s.v.maxs));
+	setorigin(self, PASSVEC3(self->s.v.origin));
+
+	self->state = STATE_CLOSED;
+	self->use = (func_t) rotate_door_use;
+	self->think = (func_t) SUB_Null;
+}

--- a/src/misc.c
+++ b/src/misc.c
@@ -822,9 +822,9 @@ void SP_ambient_general()
 			break;
 	}
 
-	if (!self->volume)
+	if (self->volume <= 0)
 	{
-		self->volume = 0.5;
+		self->volume = 0.5f;
 	}
 	trap_ambientsound (PASSVEC3(self->s.v.origin), self->noise, self->volume, self->speed);
 	ent_remove(self);

--- a/src/misc.c
+++ b/src/misc.c
@@ -799,6 +799,37 @@ void SP_ambient_swamp2()
 	ATTN_STATIC);
 }
 
+void SP_ambient_general()
+{
+	if (strnull(self->noise))
+	{
+		G_Error ("No soundfile set in noise!\n");
+		ent_remove(self);
+		return;
+	}
+
+	trap_precache_sound (self->noise);
+
+	switch ((int) ceilf(self->speed))
+	{
+		case 0:
+			self->speed = ATTN_NORM;
+			break;
+		case -1:
+			self->speed = ATTN_NONE;
+			break;
+		default:
+			break;
+	}
+
+	if (!self->volume)
+	{
+		self->volume = 0.5;
+	}
+	trap_ambientsound (PASSVEC3(self->s.v.origin), self->noise, self->volume, self->speed);
+	ent_remove(self);
+}
+
 //============================================================================
 
 void noise_think()

--- a/src/triggers.c
+++ b/src/triggers.c
@@ -1113,3 +1113,69 @@ void SP_trigger_custom_monsterjump()
 	// reset origin, well, you have to set origin each time you change solid type...
 	setorigin(self, PASSVEC3(self->s.v.origin));
 }
+
+float T_Heal(gedict_t *e, float healamount, float ignore);
+
+static void trigger_heal_touch()
+{
+	if ((match_in_progress == 1) || (!match_in_progress && cvar("k_freeze")))
+	{
+		return;
+	}
+
+	if (!streq(other->classname, "player") || ISDEAD(other))
+	{
+		return;
+	}
+
+	if (other->healtimer > g_globalvars.time)
+	{
+		return;
+	}
+
+	if (other->s.v.takedamage && (other->s.v.health < self->healmax))
+	{
+		sound (self, CHAN_AUTO, self->noise, 1, ATTN_NORM);
+
+		if ((other->s.v.health + self->healamount) > self->healmax)
+		{
+			T_Heal (other, (self->healmax - other->s.v.health), 1);
+		}
+		else
+		{
+			T_Heal (other, self->healamount, 1);
+		}
+
+		other->healtimer = g_globalvars.time + self->wait;
+	}
+}
+
+void SP_trigger_heal()
+{
+	if (strnull(self->noise))
+		self->noise = "items/r_item1.wav";
+
+	trap_precache_sound (self->noise);
+
+	InitTrigger ();
+
+	if (self->wait == 0)
+	{
+		self->wait = 1;
+	}
+	if (self->healamount == 0)
+	{
+		self->healamount = 5;
+	}
+	if (self->healmax == 0)
+	{
+		self->healmax = 100;
+	}
+	else if (self->healmax > 250)
+	{
+		self->healmax = 250;
+	}
+
+	self->healtimer = g_globalvars.time;
+	self->touch = (func_t) trigger_heal_touch;
+}


### PR DESCRIPTION
This brings along the complete set of entities used in the RCTF maps by infiniti. All of them widely available and used in the SP mapping community, nothing too fringe. Should be lots of room in mvdsv for a more bloated edict now with the lean bsp loading in place.

Intend to put together a FGD (TrenchBroom description file) in a separate repository to document these entities together with the existing ktx custom entities so it's easier for mappers to target ktx.

TL;DR:
* ambient_general - like the other ambient_* but with custom wav.
* func_bob - smooth bobbing model, can't really be done with func_train.
* func_laser - a forcefield door-like entity with pulsating alpha value that can damage player on touch.
* hiprot - func_rotate etc, from Scourge of Armagon mission pack, hated but useful.
* trigger_heal - a trigger that heals players.