### PR TITLE
FPS: word description of k_noframechecks better and set default to 0 …

### DIFF
--- a/resources/example-configs/ktx/ktx.cfg
+++ b/resources/example-configs/ktx/ktx.cfg
@@ -1,7 +1,7 @@
 // server
 set k_minrate                 2500      // minimum rate setting for players/spectators
 set sv_maxrate                500000    // maximum rate setting for players/spectators
-set k_noframechecks           0         // check for fps/speed manipulation (0 = no, 1 = yes)
+set k_noframechecks           0         // disable check for fps/speed manipulation (0 = no, 1 = yes)
 set k_no_fps_physics          0         // fps independent physics (0 = off, 1 = on)
 set k_short_gib               1         // remove gibs after 2 seconds (0 = no, 1 = yes)
 set k_exclusive               1         // number of players gets locked on game start (0 = no, 1 = yes)


### PR DESCRIPTION
…in source, 0 means do client fps checks while 1 will skip them