### PR TITLE
Send spectator info to clients

### DIFF
--- a/src/client.c
+++ b/src/client.c
@@ -4457,8 +4457,7 @@ void CheckTeamStatus()
 void SendSpecInfo()
 {
 	gedict_t *t, *p;
-	int cl;
-	char *tracking, *nick;
+	int cl, tr;
 
 	static double lastupdate = 0;
 
@@ -4471,23 +4470,8 @@ void SendSpecInfo()
 
 	for (t = world; (t = find_spc(t));)
 	{
-		if (t->ct != ctSpec)
-		{
-			continue;
-		}
-
 		cl = NUM_FOR_EDICT(t) - 1;
-		tracking = TrackWhom(t);
-
-		if (strnull(nick = ezinfokey(t, "k_nick"))) // get nick, if any, do not send name, client can guess it too
-		{
-			nick = ezinfokey(t, "k");
-		}
-
-		if (nick[0] && nick[1] && nick[2] && nick[3])
-		{
-			nick[4] = 0; // truncate nick to 4 symbols
-		}
+		tr = NUM_FOR_EDICT(PROG_TO_EDICT(t->s.v.goalentity)) - 1;	// num for player spec is tracking
 
 		for (p = world; (p = find_client(p));)
 		{
@@ -4496,7 +4480,7 @@ void SendSpecInfo()
 				continue; // ignore self
 			}
 
-			stuffcmd_flags(p, STUFFCMD_IGNOREINDEMO, "//specinfo %d \"%s\" \"%s\"\n", cl, nick, tracking);
+			stuffcmd_flags(p, STUFFCMD_IGNOREINDEMO, "//spi %d %d\n", cl, tr);
 		}
 	}
 }

--- a/src/client.c
+++ b/src/client.c
@@ -4454,6 +4454,53 @@ void CheckTeamStatus()
 	}
 }
 
+void SendSpecInfo()
+{
+	gedict_t *t, *p;
+	int cl;
+	char *tracking, *nick;
+
+	static double lastupdate = 0;
+
+	if (g_globalvars.time - lastupdate < 2)
+	{
+		return;
+	}
+
+	lastupdate = g_globalvars.time;
+
+	for (t = world; (t = find_spc(t));)
+	{
+		if (t->ct != ctSpec)
+		{
+			continue;
+		}
+
+		cl = NUM_FOR_EDICT(t) - 1;
+		tracking = TrackWhom(t);
+
+		if (strnull(nick = ezinfokey(t, "k_nick"))) // get nick, if any, do not send name, client can guess it too
+		{
+			nick = ezinfokey(t, "k");
+		}
+
+		if (nick[0] && nick[1] && nick[2] && nick[3])
+		{
+			nick[4] = 0; // truncate nick to 4 symbols
+		}
+
+		for (p = world; (p = find_client(p));)
+		{
+			if (p == t)
+			{
+				continue; // ignore self
+			}
+
+			stuffcmd_flags(p, STUFFCMD_IGNOREINDEMO, "//specinfo %d \"%s\" \"%s\"\n", cl, nick, tracking);
+		}
+	}
+}
+
 void TookWeaponHandler(gedict_t *p, int new_wp, qbool from_backpack)
 {
 	weaponName_t wp;

--- a/src/world.c
+++ b/src/world.c
@@ -1773,6 +1773,7 @@ extern float intermission_exittime;
 void CheckTiming();
 void check_fcheck();
 void CheckTeamStatus();
+void SendSpecInfo();
 void DoMVDAutoTrack(void);
 
 void FixNoSpecs(void);
@@ -1850,6 +1851,8 @@ void StartFrame(int time)
 	check_monsters_respawn();
 
 	CheckTeamStatus();
+
+	SendSpecInfo();
 
 	CheckAutoXonX(true); // switch XonX mode dependant on players + specs count
 


### PR DESCRIPTION
Currently, players have to individually request this info via the /klist command. That sucks. This change allows us to create cool hud elements to see this info in real time, alert players when specs are following them, and other fun stuff.