### PR TITLE
FRESHTEAMS: new dmm1 variation

### DIFF
--- a/src/commands.c
+++ b/src/commands.c
@@ -107,6 +107,11 @@ void ToggleFairPacks();
 void ToggleFreeze();
 void ToggleMidair();
 void SetMidairMinHeight();
+void ToggleFreshTeams();
+void ToggleFreshPacks();
+void ToggleFreshGuns();
+void ToggleFreshTime();
+void ToggleNoSweep();
 void ToggleInstagib();
 void ToggleLGC(void);
 void ToggleCGKickback();
@@ -540,6 +545,11 @@ const char CD_NODESC[] = "no desc";
 #define CD_KILL				"invoke suicide"
 #define CD_MIDAIR			"turn midair mode on/off"
 #define CD_MIDAIR_MINHEIGHT	"midair minimum frag height"
+#define CD_FRESHTEAMS		"freshteams dmm1 settings"
+#define CD_FRESHPACKS		"limit ammo in backpacks"
+#define CD_FRESHGUNS		"limit ammo when sweeping weapons"
+#define CD_FRESHTIME		"toggle weapon time in freshteams"
+#define CD_NOSWEEP			"restrict players from sweeping weapons"
 #define CD_INSTAGIB			"instagib settings"
 #define CD_BERZERK			"berzerk settings"
 #define CD_LGC				"lgc mode"
@@ -911,6 +921,11 @@ cmd_t cmds[] =
 	{ "kill", 						ClientKill, 					0, 			CF_PLAYER | CF_MATCHLESS, 												CD_KILL },
 	{ "midair", 					ToggleMidair, 					0, 			CF_PLAYER | CF_SPC_ADMIN, 												CD_MIDAIR },
 	{ "midair_minheight", 			SetMidairMinHeight, 			0, 			CF_PLAYER | CF_SPC_ADMIN, 												CD_MIDAIR_MINHEIGHT },
+	{ "fresh", 						ToggleFreshTeams, 				0, 			CF_PLAYER | CF_SPC_ADMIN, 												CD_FRESHTEAMS },
+	{ "freshpacks", 				ToggleFreshPacks, 				0, 			CF_PLAYER | CF_SPC_ADMIN, 												CD_FRESHPACKS },
+	{ "freshguns", 					ToggleFreshGuns, 				0, 			CF_PLAYER | CF_SPC_ADMIN, 												CD_FRESHGUNS },
+	{ "freshtime", 					ToggleFreshTime, 				0, 			CF_PLAYER | CF_SPC_ADMIN, 												CD_FRESHTIME },
+	{ "nosweep", 					ToggleNoSweep, 					0, 			CF_PLAYER | CF_SPC_ADMIN, 												CD_NOSWEEP },
 	{ "instagib", 					ToggleInstagib, 				0, 			CF_PLAYER | CF_SPC_ADMIN, 												CD_INSTAGIB },
 	{ "berzerk", 					ToggleBerzerk, 					0, 			CF_PLAYER | CF_SPC_ADMIN, 												CD_BERZERK },
 	{ "lgcmode", 					ToggleLGC, 						0, 			CF_PLAYER | CF_SPC_ADMIN, 												CD_LGC },
@@ -4066,6 +4081,8 @@ const char common_um_init[] =
 	"k_rocketarena 0\n"				// disable Rocket Arena by default
 	"k_race 0\n"					// disable Race by default
 	"k_hoonymode 0\n"				// disable HoonyMode by default
+	"k_freshteams 0\n"				// disable FreshTeams by default
+	"k_nosweep 0\n"					// disable nosweep by default
 	"k_spec_info 1\n"				// allow spectators receive took info during game
 	"k_midair 0\n"					// midair off
 	LGCMODE_VARIABLE " 0\n"			// LGC mode off
@@ -7311,6 +7328,184 @@ void SetMidairMinHeight()
 }
 
 void W_SetCurrentAmmo();
+
+void ToggleFreshTeams()
+{
+	int k_freshteams = bound(0, cvar("k_freshteams"), 2);
+
+	if (match_in_progress)
+	{
+		return;
+	}
+
+	if (!is_rules_change_allowed())
+	{
+		return;
+	}
+
+	// Can't enable freshteams unless dmm1 is set first
+	if (deathmatch != 1)
+	{
+		G_sprint(self, 2, "FreshTeams requires dmm1\n");
+
+		return;
+	}
+
+	if (!k_freshteams)
+	{
+		cvar_set("k_freshteams", "1");
+		G_bprint(2, "%s enabled\n", "&c08fFreshTeams&r");
+	}
+	else
+	{
+		cvar_set("k_freshteams", "0");
+		G_bprint(2, "%s disabled\n", "&c08fFreshTeams&r");
+	}
+}
+
+void ToggleFreshPacks()		// FreshPacks is enabled by default when playing freshteams
+{
+	int k_freshteams = cvar("k_freshteams");
+	int k_freshpacks = bound(0, cvar("k_freshteams_limit_packs"), 1);
+
+	if (match_in_progress)
+	{
+		return;
+	}
+
+	if (!is_rules_change_allowed())
+	{
+		return;
+	}
+
+	// Can't enable nosweep unless dmm1 is set first
+	if (!k_freshteams)
+	{
+		G_sprint(self, 2, "FreshPacks requires FreshTeams (/fresh)\n");
+
+		return;
+	}
+
+	if (k_freshpacks)
+	{
+		cvar_set("k_freshteams_limit_packs", "0");
+		G_bprint(2, "%s disabled (standard dmm1 backpack ammo)\n", "&c08fFreshPacks&r");
+	}
+	else
+	{
+		cvar_set("k_freshteams_limit_packs", "1");
+		G_bprint(2, "%s enabled (FreshTeams default - limit backpack ammo)\n", "&c08fFreshPacks&r");
+	}
+}
+
+void ToggleFreshGuns() // FreshGuns is enabled by default when playing freshteams
+{
+	int k_freshteams = cvar("k_freshteams");
+	int k_freshguns = bound(0, cvar("k_freshteams_limit_sweep_ammo"), 1);
+
+	if (match_in_progress)
+	{
+		return;
+	}
+
+	if (!is_rules_change_allowed())
+	{
+		return;
+	}
+
+	// Can't enable nosweep unless dmm1 is set first
+	if (!k_freshteams)
+	{
+		G_sprint(self, 2, "FreshGuns requires FreshTeams (/fresh)\n");
+
+		return;
+	}
+
+	if (k_freshguns)
+	{
+		cvar_set("k_freshteams_limit_sweep_ammo", "0");
+		G_bprint(2, "%s disabled (standard dmm1 ammo distribution)\n", "&c08fFreshGuns&r");
+	}
+	else
+	{
+		cvar_set("k_freshteams_limit_sweep_ammo", "1");
+		G_bprint(2, "%s enabled (FreshTeams default - limit weapon ammo on sweep)\n", "&c08fFreshGuns&r");
+	}
+}
+
+void ToggleFreshTime()
+{
+	int k_freshteams = cvar("k_freshteams");
+	int k_freshtime = bound(0, cvar("k_freshteams_weapon_time"), 60);
+
+	if (match_in_progress)
+	{
+		return;
+	}
+
+	if (!is_rules_change_allowed())
+	{
+		return;
+	}
+
+	// Can't enable nosweep unless dmm1 is set first
+	if (!k_freshteams)
+	{
+		G_sprint(self, 2, "FreshTime requires FreshTeams (/fresh)\n");
+
+		return;
+	}
+
+	if (k_freshtime == 20)
+	{
+		cvar_set("k_freshteams_weapon_time", "15");
+		G_bprint(2, "%s 15 second weapons\n", "&c08fFreshTeams&r");
+	}
+	else if (k_freshtime == 15)
+	{
+		cvar_set("k_freshteams_weapon_time", "10");
+		G_bprint(2, "%s 10 second weapons\n", "&c08fFreshTeams&r");
+	}
+	else {
+		cvar_set("k_freshteams_weapon_time", "20");
+		G_bprint(2, "%s 20 second weapons (default)\n", "&c08fFreshTeams&r");
+	}
+}
+
+void ToggleNoSweep()
+{
+	int k_nosweep = bound(0, cvar("k_nosweep"), 1);
+
+	if (match_in_progress)
+	{
+		return;
+	}
+
+	if (!is_rules_change_allowed())
+	{
+		return;
+	}
+
+	// Can't enable nosweep unless dmm1 is set first
+	if (deathmatch != 1)
+	{
+		G_sprint(self, 2, "nosweep requires dmm1\n");
+
+		return;
+	}
+
+	if (k_nosweep)
+	{
+		cvar_set("k_nosweep", "0");
+		G_bprint(2, "%s disabled\n", redtext("NoSweep"));
+	}
+	else
+	{
+		cvar_set("k_nosweep", "1");
+		G_bprint(2, "%s enabled (players cannot pick up weapons they already have)\n", redtext("NoSweep"));
+	}
+}
+
 void ToggleInstagib()
 {
 	int k_instagib = bound(0, cvar("k_instagib"), 3);

--- a/src/commands.c
+++ b/src/commands.c
@@ -7331,13 +7331,6 @@ void W_SetCurrentAmmo();
 
 void ToggleFreshTeams()
 {
-	int k_freshteams = bound(0, cvar("k_freshteams"), 2);
-
-	if (match_in_progress)
-	{
-		return;
-	}
-
 	if (!is_rules_change_allowed())
 	{
 		return;
@@ -7351,27 +7344,12 @@ void ToggleFreshTeams()
 		return;
 	}
 
-	if (!k_freshteams)
-	{
-		cvar_set("k_freshteams", "1");
-		G_bprint(2, "%s enabled\n", "&c08fFreshTeams&r");
-	}
-	else
-	{
-		cvar_set("k_freshteams", "0");
-		G_bprint(2, "%s disabled\n", "&c08fFreshTeams&r");
-	}
+	cvar_toggle_msg(self, "k_freshteams", "&c08fFreshTeams&r");
 }
 
 void ToggleFreshPacks()		// FreshPacks is enabled by default when playing freshteams
 {
 	int k_freshteams = cvar("k_freshteams");
-	int k_freshpacks = bound(0, cvar("k_freshteams_limit_packs"), 1);
-
-	if (match_in_progress)
-	{
-		return;
-	}
 
 	if (!is_rules_change_allowed())
 	{
@@ -7386,27 +7364,12 @@ void ToggleFreshPacks()		// FreshPacks is enabled by default when playing fresht
 		return;
 	}
 
-	if (k_freshpacks)
-	{
-		cvar_set("k_freshteams_limit_packs", "0");
-		G_bprint(2, "%s disabled (standard dmm1 backpack ammo)\n", "&c08fFreshPacks&r");
-	}
-	else
-	{
-		cvar_set("k_freshteams_limit_packs", "1");
-		G_bprint(2, "%s enabled (FreshTeams default - limit backpack ammo)\n", "&c08fFreshPacks&r");
-	}
+	cvar_toggle_msg(self, "k_freshteams_limit_packs", "&c08fFreshPacks&r (limited backpack ammo)");
 }
 
 void ToggleFreshGuns() // FreshGuns is enabled by default when playing freshteams
 {
 	int k_freshteams = cvar("k_freshteams");
-	int k_freshguns = bound(0, cvar("k_freshteams_limit_sweep_ammo"), 1);
-
-	if (match_in_progress)
-	{
-		return;
-	}
 
 	if (!is_rules_change_allowed())
 	{
@@ -7421,27 +7384,13 @@ void ToggleFreshGuns() // FreshGuns is enabled by default when playing freshteam
 		return;
 	}
 
-	if (k_freshguns)
-	{
-		cvar_set("k_freshteams_limit_sweep_ammo", "0");
-		G_bprint(2, "%s disabled (standard dmm1 ammo distribution)\n", "&c08fFreshGuns&r");
-	}
-	else
-	{
-		cvar_set("k_freshteams_limit_sweep_ammo", "1");
-		G_bprint(2, "%s enabled (FreshTeams default - limit weapon ammo on sweep)\n", "&c08fFreshGuns&r");
-	}
+	cvar_toggle_msg(self, "k_freshteams_limit_sweep_ammo", "&c08fFreshGuns&r (limited weapon ammo on sweep)");
 }
 
 void ToggleFreshTime()
 {
 	int k_freshteams = cvar("k_freshteams");
 	int k_freshtime = bound(0, cvar("k_freshteams_weapon_time"), 60);
-
-	if (match_in_progress)
-	{
-		return;
-	}
 
 	if (!is_rules_change_allowed())
 	{
@@ -7474,13 +7423,6 @@ void ToggleFreshTime()
 
 void ToggleNoSweep()
 {
-	int k_nosweep = bound(0, cvar("k_nosweep"), 1);
-
-	if (match_in_progress)
-	{
-		return;
-	}
-
 	if (!is_rules_change_allowed())
 	{
 		return;
@@ -7494,16 +7436,7 @@ void ToggleNoSweep()
 		return;
 	}
 
-	if (k_nosweep)
-	{
-		cvar_set("k_nosweep", "0");
-		G_bprint(2, "%s disabled\n", redtext("NoSweep"));
-	}
-	else
-	{
-		cvar_set("k_nosweep", "1");
-		G_bprint(2, "%s enabled (players cannot pick up weapons they already have)\n", redtext("NoSweep"));
-	}
+	cvar_toggle_msg(self, "k_nosweep", redtext("NoSweep"));
 }
 
 void ToggleInstagib()

--- a/src/items.c
+++ b/src/items.c
@@ -802,6 +802,10 @@ void weapon_touch()
 	gedict_t *stemp;
 	int leave;
 	int real_ammo = 0;
+	int k_freshteams = cvar("k_freshteams");
+	int limit_sweep_ammo = cvar("k_freshteams_limit_sweep_ammo");
+	int k_nosweep = cvar("k_nosweep");
+	int weapon_time = k_freshteams ? cvar("k_freshteams_weapon_time") : 30;
 	char *playername;
 
 	if (ISDEAD(other))
@@ -835,47 +839,79 @@ void weapon_touch()
 
 	if (!strcmp(self->classname, "weapon_nailgun"))
 	{
-		if (leave && ((int)other->s.v.items & IT_NAILGUN))
+		if ((leave || k_nosweep) && ((int)other->s.v.items & IT_NAILGUN))
 		{
 			return;
 		}
 
 		hadammo = other->s.v.ammo_nails;
 		new = IT_NAILGUN;
-		other->s.v.ammo_nails += 30;
+
+		if (k_freshteams && limit_sweep_ammo && ((int)other->s.v.items & IT_NAILGUN))
+		{
+			other->s.v.ammo_nails += cvar("k_freshteams_sweep_ng_ammo");
+		}
+		else
+		{
+			other->s.v.ammo_nails += 30;
+		}
 	}
 	else if (!strcmp(self->classname, "weapon_supernailgun"))
 	{
-		if (leave && ((int)other->s.v.items & IT_SUPER_NAILGUN))
+		if ((leave || k_nosweep) && ((int)other->s.v.items & IT_SUPER_NAILGUN))
 		{
 			return;
 		}
 
 		hadammo = other->s.v.ammo_nails;
 		new = IT_SUPER_NAILGUN;
-		other->s.v.ammo_nails += 30;
+
+		if (k_freshteams && limit_sweep_ammo && ((int)other->s.v.items & IT_SUPER_NAILGUN))
+		{
+			other->s.v.ammo_nails += cvar("k_freshteams_sweep_sng_ammo");
+		}
+		else
+		{
+			other->s.v.ammo_nails += 30;
+		}
 	}
 	else if (!strcmp(self->classname, "weapon_supershotgun"))
 	{
-		if (leave && ((int)other->s.v.items & IT_SUPER_SHOTGUN))
+		if ((leave || k_nosweep) && ((int)other->s.v.items & IT_SUPER_SHOTGUN))
 		{
 			return;
 		}
 
 		hadammo = other->s.v.ammo_shells;
 		new = IT_SUPER_SHOTGUN;
-		other->s.v.ammo_shells += 5;
+
+		if (k_freshteams && limit_sweep_ammo && ((int)other->s.v.items & IT_SUPER_SHOTGUN))
+		{
+			other->s.v.ammo_shells += cvar("k_freshteams_sweep_ssg_ammo");
+		}
+		else
+		{
+			other->s.v.ammo_shells += 5;
+		}
 	}
 	else if (!strcmp(self->classname, "weapon_rocketlauncher"))
 	{
-		if (leave && ((int)other->s.v.items & IT_ROCKET_LAUNCHER))
+		if ((leave || k_nosweep) && ((int)other->s.v.items & IT_ROCKET_LAUNCHER))
 		{
 			return;
 		}
 
 		hadammo = other->s.v.ammo_rockets;
 		new = IT_ROCKET_LAUNCHER;
-		other->s.v.ammo_rockets += 5;
+
+		if (k_freshteams && limit_sweep_ammo && ((int)other->s.v.items & IT_ROCKET_LAUNCHER))
+		{
+			other->s.v.ammo_rockets += cvar("k_freshteams_sweep_rl_ammo");
+		}
+		else
+		{
+			other->s.v.ammo_rockets += 5;
+		}
 
 		if (!first_rl_taken)
 		{
@@ -887,25 +923,41 @@ void weapon_touch()
 	}
 	else if (!strcmp(self->classname, "weapon_grenadelauncher"))
 	{
-		if (leave && ((int)other->s.v.items & IT_GRENADE_LAUNCHER))
+		if ((leave || k_nosweep) && ((int)other->s.v.items & IT_GRENADE_LAUNCHER))
 		{
 			return;
 		}
 
 		hadammo = other->s.v.ammo_rockets;
 		new = IT_GRENADE_LAUNCHER;
-		other->s.v.ammo_rockets += 5;
+
+		if (k_freshteams && limit_sweep_ammo && ((int)other->s.v.items & IT_GRENADE_LAUNCHER))
+		{
+			other->s.v.ammo_rockets += cvar("k_freshteams_sweep_gl_ammo");
+		}
+		else
+		{
+			other->s.v.ammo_rockets += 5;
+		}
 	}
 	else if (!strcmp(self->classname, "weapon_lightning"))
 	{
-		if (leave && ((int)other->s.v.items & IT_LIGHTNING))
+		if ((leave || k_nosweep) && ((int)other->s.v.items & IT_LIGHTNING))
 		{
 			return;
 		}
 
 		hadammo = other->s.v.ammo_cells;
 		new = IT_LIGHTNING;
-		other->s.v.ammo_cells += 15;
+
+		if (k_freshteams && limit_sweep_ammo && ((int)other->s.v.items & IT_LIGHTNING))
+		{
+			other->s.v.ammo_cells += cvar("k_freshteams_sweep_lg_ammo");
+		}
+		else
+		{
+			other->s.v.ammo_cells += 15;
+		}
 	}
 	else
 	{
@@ -992,9 +1044,9 @@ void weapon_touch()
 	// we still try to use SUB_regen and do final decision there if we should regen item.
 	if (deathmatch != 2)
 	{
-		self->s.v.nextthink = g_globalvars.time + 30;
+		self->s.v.nextthink = g_globalvars.time + weapon_time;
 		stuffcmd_flags(other, STUFFCMD_DEMOONLY, "//ktx took %d %d %d\n", NUM_FOR_EDICT(self),
-						30, NUM_FOR_EDICT(other));
+						weapon_time, NUM_FOR_EDICT(other));
 	}
 
 	self->think = (func_t) SUB_regen;
@@ -1120,6 +1172,7 @@ void ammo_touch()
 {
 	int ammo, weapon, best;
 	int real_ammo = 0;
+	qbool freshteams_fast_ammo = (cvar("k_freshteams") && cvar("k_freshteams_fast_ammo"));
 	gedict_t *stemp;
 	char *playername;
 
@@ -1270,6 +1323,12 @@ void ammo_touch()
 	if ((deathmatch == 3) || (deathmatch == 5))
 	{
 		self->s.v.nextthink = g_globalvars.time + 15;
+	}
+
+	// If playing freshteams and fast_ammo is enabled, set ammo respawn time same as weapons
+	if (freshteams_fast_ammo)
+	{
+		self->s.v.nextthink = g_globalvars.time + cvar("k_freshteams_weapon_time");
 	}
 
 	self->think = (func_t) SUB_regen;
@@ -2586,6 +2645,7 @@ void DropBackpack()
 	gedict_t *item;
 	float f1;
 	char *playername;
+	qbool fresh_packs = (cvar("k_freshteams") && cvar("k_freshteams_limit_packs"));
 
 	if (k_bloodfest)
 	{
@@ -2745,6 +2805,14 @@ void DropBackpack()
 		item->s.v.ammo_nails = min(50, item->s.v.ammo_nails);
 		item->s.v.ammo_rockets = min(25, item->s.v.ammo_rockets);
 		item->s.v.ammo_cells = min(25, item->s.v.ammo_cells);
+	}
+
+	if (fresh_packs)
+	{
+		item->s.v.ammo_shells = bound(0, item->s.v.ammo_shells, cvar("k_freshteams_pack_shells"));
+		item->s.v.ammo_nails = bound(0, item->s.v.ammo_nails, cvar("k_freshteams_pack_nails"));
+		item->s.v.ammo_rockets = bound(0, item->s.v.ammo_rockets, cvar("k_freshteams_pack_rockets"));
+		item->s.v.ammo_cells = bound(0, item->s.v.ammo_cells, cvar("k_freshteams_pack_cells"));
 	}
 
 	playername = self->netname;

--- a/src/match.c
+++ b/src/match.c
@@ -1606,6 +1606,16 @@ void PrintCountdown(int seconds)
 		strlcat(text, va("%s %4s\n", "Dmgfrags", redtext("on")), sizeof(text));
 	}
 
+	if (cvar("k_freshteams"))
+	{
+		strlcat(text, va("%s %2s\n", "&c07fFreshTeams&r", redtext("on")), sizeof(text));
+	}
+
+	if (cvar("k_nosweep"))
+	{
+		strlcat(text, va("%s %5s\n", "NoSweep", redtext("on")), sizeof(text));
+	}
+
 	if ((deathmatch == 4) && !cvar("k_midair") && !cvar("k_instagib")
 			&& !strnull(nowp = str_noweapon((int)cvar("k_disallow_weapons") & DA_WPNS)))
 	{

--- a/src/world.c
+++ b/src/world.c
@@ -876,6 +876,24 @@ void FirstFrame()
 	RegisterCvarEx("k_hoonymode_prevmap", "");
 	RegisterCvarEx("k_hoonymode_prevspawns", "");
 // }
+// { freshteams dmm1
+	RegisterCvarEx("k_freshteams", "0");
+	RegisterCvarEx("k_freshteams_weapon_time", "20");
+	RegisterCvarEx("k_freshteams_fast_ammo", "0");			// ammo spawn times match weapons
+	RegisterCvarEx("k_freshteams_limit_packs", "1");		// limit ammo in packs
+	RegisterCvarEx("k_freshteams_pack_shells", "20");		// max shells in droppacks
+	RegisterCvarEx("k_freshteams_pack_nails", "30");		// max nails in droppacks
+	RegisterCvarEx("k_freshteams_pack_rockets", "5");		// max rockets in droppacks
+	RegisterCvarEx("k_freshteams_pack_cells", "10");		// max cells in droppacks
+	RegisterCvarEx("k_freshteams_limit_sweep_ammo", "1");	// limit ammo gained when sweeping a weapon
+	RegisterCvarEx("k_freshteams_sweep_ng_ammo", "6");
+	RegisterCvarEx("k_freshteams_sweep_ssg_ammo", "1");
+	RegisterCvarEx("k_freshteams_sweep_sng_ammo", "6");
+	RegisterCvarEx("k_freshteams_sweep_gl_ammo", "1");
+	RegisterCvarEx("k_freshteams_sweep_rl_ammo", "1");
+	RegisterCvarEx("k_freshteams_sweep_lg_ammo", "3");
+	RegisterCvarEx("k_nosweep", "0");						// can't pick up weapons you already have in dmm1
+// }
 // { race
 	RegisterCvarEx("k_race", "0");
 	RegisterCvarEx("k_race_custom_models", "0");
@@ -1723,6 +1741,16 @@ void FixRules()
 	if (cvar("k_instagib") && deathmatch != 4)
 	{
 		cvar_fset("k_instagib", 0); // instagib only in dmm4
+	}
+
+	if (cvar("k_freshteams") && deathmatch != 1)
+	{
+		cvar_fset("k_freshteams", 0); // freshteams only in dmm1
+	}
+
+	if (cvar("k_nosweep") && deathmatch != 1)
+	{
+		cvar_fset("k_nosweep", 0); // nosweep only in dmm1
 	}
 
 	// ok, broadcast changes if any, a bit tech info, but this is misconfigured server


### PR DESCRIPTION
/fresh enables FreshTeams (faster weapon spawns, less ammo) 
/freshpacks toggles pack ammo limits in FreshTeams 
/freshguns toggles weapon sweep ammo limits in FreshTeams 
/freshtime toggles weapon spawn times between 20/15/10 seconds (20 is default) 
/nosweep disables weapon sweeping in dmm1 (does not require FreshTeams)