### PR TITLE
BUILD: fix strlcpy/cat defintions to be the same as system files incl…

### DIFF
--- a/include/bg_lib.h
+++ b/include/bg_lib.h
@@ -57,8 +57,8 @@ int sscanf(const char *buffer, const char *fmt, ...);
 int Q_vsnprintf(char *buffer, size_t count, const char *format, va_list argptr);
 int snprintf(char *buffer, size_t count, char const *format, ...);
 
-size_t strlcpy(char *dst, char *src, size_t siz);
-size_t strlcat(char *dst, char *src, size_t siz);
+size_t strlcpy(char *dst, const char *src, size_t siz);
+size_t strlcat(char *dst, const char *src, size_t siz);
 
 // Memory functions
 void* memmove(void *dest, const void *src, size_t count);

--- a/include/q_shared.h
+++ b/include/q_shared.h
@@ -98,8 +98,8 @@
 // most likely alredy declared in above included headers, but not for below functions,
 // because they are BSD originated, so we need declare it.
 
-size_t strlcpy(char *dst, char *src, size_t siz);
-size_t strlcat(char *dst, char *src, size_t siz);
+size_t strlcpy(char *dst, const char *src, size_t siz);
+size_t strlcat(char *dst, const char *src, size_t siz);
 
 #endif
 

--- a/src/g_syscalls.c
+++ b/src/g_syscalls.c
@@ -445,12 +445,12 @@ void trap_makevectors(float *v)
 }
 
 #if defined( __linux__ ) || defined( _WIN32 ) /* || defined( __APPLE__ ) require?*/
-size_t strlcpy(char *dst, char *src, size_t siz)
+size_t strlcpy(char *dst, const char *src, size_t siz)
 {
 	return syscall(g_strlcpy, (intptr_t) dst, (intptr_t) src, (intptr_t) siz);
 }
 
-size_t strlcat(char *dst, char *src, size_t siz)
+size_t strlcat(char *dst, const char *src, size_t siz)
 {
 	return syscall(g_strlcat, (intptr_t) dst, (intptr_t) src, (intptr_t) siz);
 }


### PR DESCRIPTION
…uded via assert.h to suppress warnings in gcc < 13 and errors in gcc => 13