### PR TITLE
BUILD: fix macos build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -148,7 +148,12 @@ if (CMAKE_C_COMPILER_ID STREQUAL "MSVC")
 	target_compile_options(${PROJECT_NAME} PRIVATE /W4)
 else()
 	target_compile_options(${PROJECT_NAME} PRIVATE -Wall)
-	target_link_options(${PROJECT_NAME} PRIVATE "-Wl,--no-undefined") # Do not allow undefined symbols while linking.
+	# Do not allow undefined symbols while linking.
+	if(APPLE)
+		target_link_options(${PROJECT_NAME} PRIVATE "-Wl,-undefined,error")
+	else()
+		target_link_options(${PROJECT_NAME} PRIVATE "-Wl,--no-undefined")
+	endif()
 	target_link_libraries(${PROJECT_NAME} PRIVATE m) # Link with libm.
 endif()
 


### PR DESCRIPTION
MacOS linker has different flags than gcc.