### PR TITLE
CA/WIPEOUT: bug fixes and improvements

### DIFF
--- a/src/clan_arena.c
+++ b/src/clan_arena.c
@@ -662,6 +662,7 @@ void CA_SendTeamInfo(gedict_t *t)
 	int kills;
 	int deaths;
 	int max_deaths;
+	int track_target;
 	gedict_t *p, *s;
 	char *tm, *nick;
 
@@ -751,10 +752,11 @@ void CA_SendTeamInfo(gedict_t *t)
 		
 		kills = bound(0, (int)p->round_kills, 999);
 		deaths = bound(0, (int)p->round_deaths, 999);
+		track_target = p->track_target ? NUM_FOR_EDICT(p->track_target) : -1;
 
-		stuffcmd(t, "//cainfo %d %d %d %d %d %d %d \"%s\" %d %d %d %d %d %d %d %d %d\n", cl,
+		stuffcmd(t, "//cainfo %d %d %d %d %d %d %d \"%s\" %d %d %d %d %d %d %d %d %d %d\n", cl,
 						origin0, origin1, origin2, h, a, items, nick, shells, nails, rockets, cells, 
-						camode, deadtype, timetospawn, kills, deaths);
+						camode, deadtype, timetospawn, kills, deaths, track_target);
 	}
 }
 

--- a/src/clan_arena.c
+++ b/src/clan_arena.c
@@ -1279,7 +1279,7 @@ void CA_player_pre_think(void)
 
 		// take no damage to health/armor withing 1 second of respawn
 		// or during endround
-		if (((self->alive_time >= 1) || !self->round_deaths) && !ca_round_pause)
+		if (self->in_play && ((self->alive_time >= 1) || !self->round_deaths) && !ca_round_pause)
 		{
 			self->no_pain = false;
 		}

--- a/src/combat.c
+++ b/src/combat.c
@@ -483,10 +483,23 @@ void T_Damage(gedict_t *targ, gedict_t *inflictor, gedict_t *attacker, float dam
 			}
 		}
 		
-		// don't accept any damage in CA modes if no_pain is true (ie during respawn in wipeout)
+		// don't accept any damage in CA modes if no_pain is true 
 		if (targ->no_pain)
-		{
-			tp4teamdmg = true; // don't take damage but still get stopped/bounced by weapon fire
+		{	
+			if (attacker == targ)
+			{
+				tp4teamdmg = true; // don't take damage but still get stopped/bounced by weapon fire
+			}
+			else 
+			{
+				if (targ->invincible_sound < g_globalvars.time)
+				{
+					sound(targ, CHAN_AUTO, "items/protect3.wav", 0.75, ATTN_NORM);
+					targ->invincible_sound = g_globalvars.time + 2;
+				}
+	
+				return;
+			}
 		}
 	}
 


### PR DESCRIPTION
- Fixed a bug that causes dead players to take damage in certain situations
- Spawning players cannot be bounced by rockets/grenades
- Tell the client who dead players are tracking (for better demo playback)