### PR TITLE
Wipeout updates

### DIFF
--- a/src/clan_arena.c
+++ b/src/clan_arena.c
@@ -1277,9 +1277,8 @@ void CA_player_pre_think(void)
 			self->alive_time = g_globalvars.time - self->time_of_respawn;
 		}
 
-		// take no damage to health/armor withing 1 second of respawn
-		// or during endround
-		if (self->in_play && ((self->alive_time >= 1) || !self->round_deaths) && !ca_round_pause)
+		// take no damage to health/armor within 1 second of respawn or during endround
+		if ((match_in_progress == 2) && self->in_play && ((self->alive_time >= 1) || !self->round_deaths) && !ca_round_pause)
 		{
 			self->no_pain = false;
 		}

--- a/src/clan_arena.c
+++ b/src/clan_arena.c
@@ -1278,7 +1278,7 @@ void CA_player_pre_think(void)
 		}
 
 		// take no damage to health/armor within 1 second of respawn or during endround
-		if ((match_in_progress == 2) && self->in_play && ((self->alive_time >= 1) || !self->round_deaths) && !ca_round_pause)
+		if (self->in_play && ((self->alive_time >= 1) || !self->round_deaths) && !ca_round_pause)
 		{
 			self->no_pain = false;
 		}

--- a/src/clan_arena.c
+++ b/src/clan_arena.c
@@ -91,10 +91,24 @@ int calc_respawn_time(gedict_t *p, int offset)
 	qbool isWipeout = (cvar("k_clan_arena") == 2);
 	int max_deaths = cvar("k_clan_arena_max_respawns");
 	int time = 999;
+	int teamsize = 0;
+	int multiple;
+	gedict_t *p2;
+
+	// count players on team
+	for (p2 = world; (p2 = find_plr_same_team(p2, getteam(p)));)
+	{
+		teamsize++;
+	}
+
+	multiple = teamsize + 1;
 
 	if (isWipeout && (p->round_deaths+offset <= max_deaths))
 	{
-		time = p->round_deaths+offset == 1 ? 5 : (p->round_deaths-1+offset) * 10;
+		// if 4 players on team, the spawn times are 5, 10, 20, 30
+		// if 3 players on team, the spawn times are 4, 8, 16, 24
+		// if 2 players on team, the spawn times are 3, 6, 12, 18
+		time = p->round_deaths+offset == 1 ? multiple : (p->round_deaths-1+offset) * (multiple*2);
 	}
 
 	return time;

--- a/src/clan_arena.c
+++ b/src/clan_arena.c
@@ -1365,7 +1365,6 @@ void CA_Frame(void)
 		int e_last_alive;
 		char str_last_alive[25];
 		char str_e_last_alive[25];
-		char spawncount[5];
 
 		for (p = world; (p = find_plr(p));)
 		{
@@ -1404,26 +1403,9 @@ void CA_Frame(void)
 			// both you and the enemy are the last alive on your team
 			else if (p->in_play && p->alive_time > 2 && last_alive && e_last_alive)
 			{
-				// if teammate will spawn before or at the same time as enemy
-				if (last_alive != 999 && last_alive <= e_last_alive)
-				{
-					sprintf(spawncount, "%d", last_alive);
-				}
-				// if enemy spawns before teammate
-				else if (e_last_alive != 999 && e_last_alive < last_alive)
-				{
-					sprintf(str_e_last_alive, "%d", e_last_alive);
-					sprintf(spawncount, "%s", redtext(str_e_last_alive));
-				}
-				// nobody else is spawning
-				else
-				{
-					sprintf(spawncount, "%s", " ");
-				}
-
-				//sprintf(str_last_alive, "%d", last_alive);
+				sprintf(str_last_alive, "%d", last_alive);
 				sprintf(p->cptext, "\n\n\n\n\n\n%s\n\n\n%s\n\n\n\n", 
-								redtext("1 on 1"), spawncount);
+								redtext("1 on 1"), last_alive == 999 ? " " : redtext(str_last_alive));
 
 				G_centerprint(p, "%s", p->cptext);
 			}

--- a/src/clan_arena.c
+++ b/src/clan_arena.c
@@ -101,7 +101,7 @@ int calc_respawn_time(gedict_t *p, int offset)
 		teamsize++;
 	}
 
-	multiple = teamsize + 1;
+	multiple = bound(3, teamsize+1, 6);	// first respawn won't take more than 6 seconds regardless of team size
 
 	if (isWipeout && (p->round_deaths+offset <= max_deaths))
 	{

--- a/src/clan_arena.c
+++ b/src/clan_arena.c
@@ -1363,8 +1363,8 @@ void CA_Frame(void)
 	{
 		int last_alive;
 		int e_last_alive;
-		char str_last_alive[5];
-		char str_e_last_alive[5];
+		char str_last_alive[25];
+		char str_e_last_alive[25];
 		char spawncount[5];
 
 		for (p = world; (p = find_plr(p));)

--- a/src/combat.c
+++ b/src/combat.c
@@ -484,7 +484,7 @@ void T_Damage(gedict_t *targ, gedict_t *inflictor, gedict_t *attacker, float dam
 		}
 		
 		// don't accept any damage in CA modes if no_pain is true 
-		if (targ->no_pain)
+		if (targ->no_pain && (match_in_progress == 2))
 		{	
 			if (attacker == targ)
 			{

--- a/src/combat.c
+++ b/src/combat.c
@@ -491,7 +491,7 @@ void T_Damage(gedict_t *targ, gedict_t *inflictor, gedict_t *attacker, float dam
 		}
 		
 		// don't accept any damage in CA modes if no_pain is true 
-		if (targ->no_pain && (match_in_progress == 2))
+		if ((targ->no_pain || (attacker->no_pain && attacker->in_play)) && (match_in_progress == 2))
 		{	
 			if (attacker == targ)
 			{

--- a/src/combat.c
+++ b/src/combat.c
@@ -449,6 +449,13 @@ void T_Damage(gedict_t *targ, gedict_t *inflictor, gedict_t *attacker, float dam
 	float playerheight = 0, midheight = 0;
 	qbool midair = false, inwater = false, do_dmg = false, rl_dmg = false, stomp_dmg = false;
 
+	// used by buttons and triggers to set activator for target firing
+	damage_attacker = attacker;
+	damage_inflictor = inflictor;
+
+	attackerteam = getteam(attacker);
+	targteam = getteam(targ);
+
 	// can't apply damage to dead
 	if (!targ->s.v.takedamage || ISDEAD(targ))
 	{
@@ -492,7 +499,7 @@ void T_Damage(gedict_t *targ, gedict_t *inflictor, gedict_t *attacker, float dam
 			}
 			else 
 			{
-				if (targ->invincible_sound < g_globalvars.time)
+				if (targ->in_play && (targ->invincible_sound < g_globalvars.time) && strneq(targteam, attackerteam))
 				{
 					sound(targ, CHAN_AUTO, "items/protect3.wav", 0.75, ATTN_NORM);
 					targ->invincible_sound = g_globalvars.time + 2;
@@ -502,13 +509,6 @@ void T_Damage(gedict_t *targ, gedict_t *inflictor, gedict_t *attacker, float dam
 			}
 		}
 	}
-
-	// used by buttons and triggers to set activator for target firing
-	damage_attacker = attacker;
-	damage_inflictor = inflictor;
-
-	attackerteam = getteam(attacker);
-	targteam = getteam(targ);
 
 	if ((int)cvar("k_midair"))
 	{

--- a/src/g_userinfo.c
+++ b/src/g_userinfo.c
@@ -398,6 +398,10 @@ qbool FixPlayerTeam(char *newteam)
 
 		return false;
 	}
+	if (isCA() && !match_in_progress)
+	{
+		return false;
+	}
 
 	// do not allow change team in game / countdown
 	if (match_in_progress || coop)


### PR DESCRIPTION
Various wipeout related updates:

- Simplified "1on1" notifications
- Spawning players cannot take or give damage for 1 second (but can still rocket jump)
- Respawn times are now calculated based on  number of players in team. This should improve 2v3 or 3v4 experience.
- Some minor bug fixes with sounds and team settings