### PR TITLE
socd detection

### DIFF
--- a/include/progs.h
+++ b/include/progs.h
@@ -944,6 +944,17 @@ typedef struct gedict_s
 	float fIllegalFPSWarnings;
 // ILLEGALFPS]
 
+// SOCD detectioin
+	float fStrafeChangeCount;
+	float fFramePerfectStrafeChangeCount;
+	int   socdDetected;
+	int   socdChecksCount;
+	float fLastSideMoveSpeed;
+	int   matchStrafeChangeCount;
+	int   matchPerfectStrafeCount;
+	int   nullStrafeCount;
+// SOCD
+
 	float shownick_time;					// used to force centerprint is off at desired time
 	clientType_t ct;						// client type for client edicts
 // { timing

--- a/src/client.c
+++ b/src/client.c
@@ -1658,6 +1658,16 @@ void ClientConnect()
 		SendIntermissionToClient();
 	}
 
+// SOCD
+	self->socdChecksCount = 0;
+	self->socdDetected = 0;
+	self->fStrafeChangeCount = 0;
+	self->fFramePerfectStrafeChangeCount = 0;
+	self->fLastSideMoveSpeed = 0;
+	self->matchStrafeChangeCount = 0;
+	self->matchPerfectStrafeCount = 0;
+	self->nullStrafeCount = 0;
+
 // ILLEGALFPS[
 
 	// Zibbo's frametime checking code
@@ -3519,6 +3529,60 @@ void PlayerPreThink()
 		BotPreThink(self);
 	}
 #endif
+
+// SOCD detection
+
+	float fSideMoveSpeed = self->movement[1];
+
+	if ( (fSideMoveSpeed != 0) && (fSideMoveSpeed != self->fLastSideMoveSpeed) && (self->nullStrafeCount < 3) ) //strafechange
+	{
+		self->fStrafeChangeCount += 1;
+		if (match_in_progress)
+			self->matchStrafeChangeCount += 1;
+
+		if ((fSideMoveSpeed != 0) && (self->fLastSideMoveSpeed != 0))
+		{
+			self->fFramePerfectStrafeChangeCount += 1;
+			if (match_in_progress)
+				self->matchPerfectStrafeCount += 1;
+		}
+
+		self->nullStrafeCount = 0;
+
+		//debug
+		if (0 == strcmp(self->netname, "blaze"))
+		{
+			G_bprint(PRINT_HIGH, "Movement: %3.1f %3.1f %3.1f\n",
+				self->movement[0], self->movement[1], self->movement[2]);
+		}
+	}
+	else
+	{
+		if (0 == fSideMoveSpeed)
+			self->nullStrafeCount += 1;
+		else
+			self->nullStrafeCount = 0;
+	}
+
+	self->fLastSideMoveSpeed = fSideMoveSpeed;
+
+	if (self->fStrafeChangeCount >= 16)
+	{
+		if (self->fFramePerfectStrafeChangeCount / self->fStrafeChangeCount >= 0.75)
+		{
+			self->socdDetected += 1;
+			if ( (!match_in_progress) && (!self->isBot) )
+			{
+				G_bprint(PRINT_HIGH,
+					"Warning! %s: SOCD movement assistance detected. Please disable iDrive or keyboard SOCD features.\n",
+					self->netname);
+			}
+		}
+
+		self->socdChecksCount += 1;
+		self->fStrafeChangeCount = 0;
+		self->fFramePerfectStrafeChangeCount = 0;
+	}
 
 // ILLEGALFPS[
 

--- a/src/commands.c
+++ b/src/commands.c
@@ -8114,14 +8114,42 @@ void fcheck()
 
 	if (!is_real_adm(self))
 	{
-		if (strneq(arg_x, "f_version") && strneq(arg_x, "f_modified") && strneq(arg_x, "f_server"))
+		if (strneq(arg_x, "f_version") && strneq(arg_x, "f_modified") && strneq(arg_x, "f_server") && strneq(arg_x, "f_movement"))
 		{
 			G_sprint(self, 2, "You are not allowed to check \020%s\021\n"
-						"available checks are: f_version, f_modified and f_server\n",
+						"available checks are: f_version, f_modified, f_server and f_movement\n",
 						arg_x);
 
 			return;
 		}
+	}
+
+	if (streq(arg_x, "f_movement"))
+	{
+		G_bprint(2, "%s is checking \020%s\021\n", self->netname, arg_x);
+
+		for (i = 1; i <= MAX_CLIENTS; i++)
+		{
+			if (!strnull(g_edicts[i].netname))
+			{
+				if (g_edicts[i].socdDetected > 0)
+				{
+					G_bprint(2, "%s: SOCD movement assistance detected!\n", g_edicts[i].netname);
+				}
+				else
+				{
+					if (g_edicts[i].socdChecksCount >= 2)
+					{
+						G_bprint(2, "%s: no assistance detected.\n", g_edicts[i].netname);
+					}
+					else
+					{
+						G_bprint(2, "%s: not enough movement to run SOCD detection. Please move around a map.\n", g_edicts[i].netname);
+					}
+				}
+			}
+		}
+		return;
 	}
 
 	for (i = 1; i <= MAX_CLIENTS; i++)

--- a/src/stats.c
+++ b/src/stats.c
@@ -763,6 +763,14 @@ void OnePlayerStats(gedict_t *p, int tp)
 					p->ps.vel_frames > 0 ? p->ps.velocity_sum / p->ps.vel_frames : 0.);
 	}
 
+	if (!p->isBot)
+	{
+		G_bprint(2, "%s: %s:%d/%d %s:%d/%d\n", redtext("Movement"), redtext("Perfect strafes"),
+			p->matchPerfectStrafeCount, p->matchStrafeChangeCount, redtext("SOCD detections"),
+			p->socdDetected, p->socdChecksCount);
+	}
+
+
 	// armors + megahealths
 	if (!lgc_enabled())
 	{


### PR DESCRIPTION
1) Automatic warning if the server detects SOCD (can be enabled or disabled by the admin by modifying k_allow_socd_warning)
2) Command to check f_movement, summarizing for each player if the server detected anything. (ex: cmd check f_movement)
3) End-of-game stats to show if SOCD was in use.