### PR TITLE
Ctf Frogbots

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -87,6 +87,7 @@ set(SRC_COMMON
 	"${DIR_SRC}/maps_map_dm3.c"
 	"${DIR_SRC}/maps_map_dm4.c"
 	"${DIR_SRC}/maps_map_dm6.c"
+	"${DIR_SRC}/maps_map_e2m2.c"
 	"${DIR_SRC}/maps_map_povdmm4.c"
 	"${DIR_SRC}/marker_load.c"
 	"${DIR_SRC}/marker_util.c"

--- a/include/fb_globals.h
+++ b/include/fb_globals.h
@@ -87,6 +87,10 @@ extern gedict_t *dropper;
 #define FB_PREFER_ROCKET_LAUNCHER	1
 #define FB_PREFER_LIGHTNING_GUN		2
 
+#define FB_CTF_ROLE_ATTACK          0
+#define FB_CTF_ROLE_MIDFIELD        1
+#define FB_CTF_ROLE_DEFEND          2
+
 #define GAME_ENABLE_POWERUPS		1
 #define GAME_ENABLE_RUNES			2
 #define GAME_RUNE_RJ				4
@@ -132,6 +136,9 @@ extern gedict_t *dropper;
 #define BOTPATH_CURLJUMP_HINT		(1 << 23)
 #define BOTPATH_FULL_AIRCONTROL		(1 << 24)
 #define BOTPATH_RJ_IN_PROGRESS		(1 << 25)
+#define HOOK                        (1 << 26)
+#define LOOK_BUTTON                 (1 << 27)	// Indicates path which points to a button to shoot 
+#define FIRE_BUTTON                 (1 << 28)   // Set when a bot should try shooting a button
 #define DELIBERATE_AIR_WAIT_GROUND	(DELIBERATE_AIR | WAIT_GROUND)
 #define SAVED_DESCRIPTION			(DM6_DOOR | ROCKET_JUMP | JUMP_LEDGE | VERTICAL_PLATFORM | BOTPATH_DOOR | BOTPATH_DOOR_CLOSED | NO_DODGE)
 #define NOT_ROCKET_JUMP				(~ROCKET_JUMP)
@@ -149,6 +156,10 @@ extern gedict_t *dropper;
 #define MARKER_DYNAMICALLY_ADDED	256		// Added dynamically by server.  Do not include in .bot file generation
 #define MARKER_EXPLICIT_VIEWOFFSET	512		// Viewoffset has been set by map definition and should be included in .bot file generation
 #define MARKER_NOTOUCH				1024	// Not touchable - used when two markers on top of each other
+#define MARKER_FLAG1_DEFEND         2048    // Point used to defend flag 1 (red)
+#define MARKER_FLAG2_DEFEND         4096    // Point used to defend flag 1 (blue)
+#define MARKER_LOOK_BUTTON          8192    // A button can be shot from this marker - set automatically
+#define MARKER_E2M2_DISCHARGE       16384   // Bots on red team will run here then discharge at the start of the map
 
 // Bot flags (FIXME: fb.state?  check.  consistent naming, comment with descriptions)
 #define CAMPBOT						1
@@ -169,6 +180,7 @@ float boomstick_only(void);
 
 float CountTeams(void);
 qbool EnemyDefenceless(gedict_t *self);
+qbool EnemyHasFlag (gedict_t* self);
 
 qbool enemy_shaft_attack(gedict_t *self, gedict_t *enemy);
 float W_BestWeapon(void);
@@ -181,6 +193,7 @@ float WeaponCode(float w);
 float crandom(void);
 
 void BotCanRocketJump(gedict_t *self);
+void BotCanHook(gedict_t *self);
 qbool VisibleEntity(gedict_t *ent);
 gedict_t* IdentifyMostVisibleTeammate(gedict_t *self);
 float anglemod(float v);
@@ -237,11 +250,11 @@ gedict_t* HigherSightFromFunction(gedict_t *from_marker, gedict_t *to_marker);
 gedict_t* SightFromMarkerFunction(gedict_t *from_marker, gedict_t *to_marker);
 gedict_t* SubZoneNextPathMarker(gedict_t *from_marker, gedict_t *to_marker);
 float SubZoneArrivalTime(float zone_time, gedict_t *middle_marker, gedict_t *to_marker,
-							qbool rl_routes);
+							qbool rl_routes, qbool hook_routes);
 float SightFromTime(gedict_t *from_marker, gedict_t *to_marker);
-void ZoneMarker(gedict_t *from_marker, gedict_t *to_marker, qbool path_normal, qbool rj_routes);
+void ZoneMarker(gedict_t *from_marker, gedict_t *to_marker, qbool path_normal, qbool rj_routes, qbool hook_routes);
 gedict_t* ZonePathMarker(gedict_t *from_marker, gedict_t *to_marker, qbool path_normal,
-							qbool rl_jump_routes);
+							qbool rl_jump_routes, qbool hook_routes);
 
 // botweap.qc
 void FrogbotSetFirepower(gedict_t *self);
@@ -267,6 +280,7 @@ void BotDamageInflictedEvent(gedict_t *attacker, gedict_t *targ);
 void CheckCombatJump(gedict_t *self);
 //void BotInLava(void);
 void BotPerformRocketJump(gedict_t *self);
+void BotPerformHook(gedict_t *self);
 
 // botgoal.qc
 void UpdateGoal(gedict_t *self);
@@ -288,8 +302,8 @@ void SetMarkerPathFlags(int marker_number, int path_index, int flags);
 void SetMarkerPath(int source_marker, int path_index, int next_marker);
 void SetMarkerViewOffset(int marker, float zOffset);
 
-#define FROGBOT_PATH_FLAG_OPTIONS "w6rjva"
-#define FROGBOT_MARKER_FLAG_OPTIONS "u6fbte"
+#define FROGBOT_PATH_FLAG_OPTIONS "w6rjvahl"
+#define FROGBOT_MARKER_FLAG_OPTIONS "u6fbte12"
 
 // added for ktx
 qbool fb_lg_disabled(void);
@@ -343,7 +357,7 @@ void SetJumpFlag(gedict_t *player, qbool jumping, const char *explanation);
 void PathScoringLogic(float goal_respawn_time, qbool be_quiet, float lookahead_time,
 						qbool path_normal, vec3_t player_origin, vec3_t player_direction,
 						gedict_t *touch_marker_, gedict_t *goalentity_marker, qbool rocket_alert,
-						qbool rocket_jump_routes_allowed, qbool trace_bprint, gedict_t *player,
+						qbool rocket_jump_routes_allowed, qbool hook_routes_allowed, qbool trace_bprint, gedict_t *player,
 						float *best_score, gedict_t **linked_marker_, int *new_path_state,
 						int *new_angle_hint, int *new_rj_frame_delay, float new_rj_angles[2]);
 

--- a/include/g_local.h
+++ b/include/g_local.h
@@ -620,6 +620,7 @@ void RegenFlags(qbool yes);
 void AddHook(qbool yes);
 void CTF_Obituary(gedict_t *targ, gedict_t *attacker);
 void CTF_CheckFlagsAsKeys(void);
+void TossFlag(void);
 
 // logs.c
 void log_open(const char *fmt, ...) PRINTF_FUNC(1);

--- a/include/progs.h
+++ b/include/progs.h
@@ -419,7 +419,7 @@ typedef void (*fb_entity_funcref_t)(struct gedict_s* item);
 #define NUMBER_PATHS	8
 #endif
 #ifndef NUMBER_SUBZONES
-#define NUMBER_SUBZONES	32
+#define NUMBER_SUBZONES	128 // TODO hiipe - check this, should be ok though?
 #endif
 
 typedef struct fb_runaway_route_s {
@@ -433,6 +433,7 @@ typedef struct fb_path_s {
 	struct gedict_s* next_marker;	// next marker in the graph
 	float time;						// time to travel if walking (0 if teleporting)
 	float rj_time;					// time to travel if using rocket jump
+	float hook_time;				// time to travel if using hook
 	int flags;						// hints on how to travel to next marker
 
 	short angle_hint;				// When travelling to marker, offset to standard angle (+ = anti-clockwise)
@@ -445,14 +446,18 @@ typedef struct fb_goal_s {
 	struct gedict_s* next_marker;
 	float time;
 	struct gedict_s* next_marker_rj;
+	struct gedict_s* next_marker_hook;
 	float rj_time;
+	float hook_time;
 } fb_goal_t;
 
 typedef struct fb_subzone_s {
 	struct gedict_s* next_marker;
 	float time;
 	struct gedict_s* next_marker_rj;
+	struct gedict_s* next_marker_hook;
 	float rj_time;
+	float hook_time;
 } fb_subzone_t;
 
 typedef struct fb_zone_s {
@@ -466,6 +471,11 @@ typedef struct fb_zone_s {
 	struct gedict_s* marker_rj;
 	float rj_time;
 	struct gedict_s* next_rj;
+
+	// Hook
+	struct gedict_s* marker_hook;
+	float hook_time;
+	struct gedict_s* next_hook;
 
 	float reverse_time;
 	struct gedict_s* reverse_marker;
@@ -524,6 +534,8 @@ typedef struct fb_botskill_s {
 	float movement;
 	float combat_jump_chance;
 	float missile_dodge_time;				// minimum time in seconds before bot dodges missile
+
+	int   ctf_role;                         // attack, midfield or defense
 
 	qbool customised;						// if set, customised file
 
@@ -685,6 +697,12 @@ typedef struct fb_entvars_s {
 	int rocketJumpFrameDelay;					// active delay between jumping and firing
 	int rocketJumpAngles[2];					// pitch/yaw for rocket jump angle
 	int lavaJumpState;							// keep track of submerge/rise/fire sequence
+
+	// Hook logic
+	qbool canHook;
+	qbool hooking;
+	struct gedict_s* hookTarget;
+	vec3_t hookOldPosition;
 
 	// Editor
 	int last_jump_frame;						// framecount when player last jumped.  used to help setting rj fields

--- a/src/bot_botenemy.c
+++ b/src/bot_botenemy.c
@@ -123,9 +123,9 @@ static void BestEnemy_apply(gedict_t *test_enemy, float *best_score, gedict_t **
 	look_marker = SightFromMarkerFunction(from_marker, to_marker);
 	if (look_marker != NULL)
 	{
-		ZoneMarker(from_marker, look_marker, path_normal, test_enemy->fb.canRocketJump);
+		ZoneMarker(from_marker, look_marker, path_normal, test_enemy->fb.canRocketJump, test_enemy->fb.canHook);
 		traveltime = SubZoneArrivalTime(zone_time, middle_marker, look_marker,
-										test_enemy->fb.canRocketJump);
+										test_enemy->fb.canRocketJump, test_enemy->fb.canHook);
 		enemy_score = traveltime + g_random();
 	}
 	else
@@ -134,7 +134,10 @@ static void BestEnemy_apply(gedict_t *test_enemy, float *best_score, gedict_t **
 		enemy_score = look_traveltime + g_random();
 	}
 
-	if (enemy_score < *best_score && look_marker != NULL)
+	// Prioritize enemy with flag
+	if (test_enemy->ctf_flag & CTF_FLAG) enemy_score /= 2;
+
+	if (enemy_score < *best_score && look_marker != NULL) // TODO hiipe - crashes here sometimes! Surely it should be possible for look_marker to be NULL?
 	{
 		vec3_t marker_view;
 		vec3_t to_marker_view;

--- a/src/bot_botenemy.c
+++ b/src/bot_botenemy.c
@@ -134,7 +134,7 @@ static void BestEnemy_apply(gedict_t *test_enemy, float *best_score, gedict_t **
 		enemy_score = look_traveltime + g_random();
 	}
 
-	if (enemy_score < *best_score)
+	if (enemy_score < *best_score && look_marker != NULL)
 	{
 		vec3_t marker_view;
 		vec3_t to_marker_view;

--- a/src/bot_botimp.c
+++ b/src/bot_botimp.c
@@ -52,6 +52,8 @@
 #define FB_CVAR_COMBATJUMP_CHANCE "k_fbskill_combatjump"
 #define FB_CVAR_MISSILEDODGE_TIME "k_fbskill_missiledodge"
 
+#define FB_CVAR_CTF_ROLE "k_fbskill_ctf_role"
+
 static float RangeOverSkill(int skill_level, float minimum, float maximum)
 {
 	float skill = skill_level * 1.0f / (MAX_FROGBOT_SKILL - MIN_FROGBOT_SKILL);
@@ -145,6 +147,8 @@ void RegisterSkillVariables(void)
 	RegisterCvar(FB_CVAR_COMBATJUMP_CHANCE);
 	RegisterCvar(FB_CVAR_MISSILEDODGE_TIME);
 
+	RegisterCvar(FB_CVAR_CTF_ROLE);
+
 	RegisterCvar(FB_CVAR_DISTANCEERROR);
 	RegisterCvar(FB_CVAR_PAIN_VOLATILITY_INCREASE);
 	RegisterCvar(FB_CVAR_SELF_MIDAIR_VOLATILITY_INCREASE);
@@ -208,6 +212,14 @@ qbool SetAttributesBasedOnSkill(int skill)
 	cvar_fset(FB_CVAR_MOVEMENT_WIGGLEFRAMES, RangeOverSkill(skill, 30, 20));
 	cvar_fset(FB_CVAR_COMBATJUMP_CHANCE, RangeOverSkill(skill, 0.03f, 0.1f));
 	cvar_fset(FB_CVAR_MISSILEDODGE_TIME, RangeOverSkill(skill, 1.0f, 0.5f));
+
+	// CTF skill
+	if (isCTF())
+	{
+		// Must have much lookahead time in CTF to be able to reach flags etc. Is variation even needed?
+		cvar_fset(FB_CVAR_LOOKAHEADTIME, RangeOverSkill(skill, 40.0f, 50.0f));
+		cvar_fset(FB_CVAR_CTF_ROLE, (int)CountBots() % 3);
+	}
 
 	// Customise
 	{
@@ -292,14 +304,21 @@ void SetAttribs(gedict_t *self, qbool customised)
 
 char* BotNameEnemy(int botNumber)
 {
-	char *names[] =
+	char* names[] =
 		{ ": Timber", ": Sujoy", ": Nightwing", ": Cenobite", ": Thresh", ": Frick", ": Unholy",
-				": Reptile", ": Nikodemus", ": Paralyzer", ": Xenon", ": Spice"
-						": Kornelia", ": Rix", ": Batch", ": Gollum" };
+			": Reptile", ": Nikodemus", ": Paralyzer", ": Xenon", ": Spice"
+					": Kornelia", ": Rix", ": Batch", ": Gollum" };
+
+	char *ctf_names[] = { ": Hippo", ": Velokitty", ": Shiny", ": Zagg" };
+
 	char *custom_name = cvar_string(va("k_fb_name_enemy_%d", botNumber));
 
 	if (strnull(custom_name))
 	{
+		if (isCTF())
+		{
+			return ctf_names[(int)bound(0, botNumber, sizeof(ctf_names) / sizeof(ctf_names[0]) - 1)];
+		}
 		return names[(int)bound(0, botNumber, sizeof(names) / sizeof(names[0]) - 1)];
 	}
 
@@ -308,14 +327,21 @@ char* BotNameEnemy(int botNumber)
 
 char* BotNameFriendly(int botNumber)
 {
-	char *names[] =
+	char* names[] =
 		{ "> MrJustice", "> DanJ", "> Gunner", "> Tele", "> Jakey", "> Parrais", "> Thurg",
-				"> Kool", "> Zaphod", "> Dreamer", "> Mandrixx", "> Skill5", "> Vid", "> Soul99",
-				"> Jon", "> Gaz" };
+			"> Kool", "> Zaphod", "> Dreamer", "> Mandrixx", "> Skill5", "> Vid", "> Soul99",
+			"> Jon", "> Gaz" };
+
+	char *ctf_names[] = { "> Micro", "> Elfeo", "> Malice", "> Killton" };
+
 	char *custom_name = cvar_string(va("k_fb_name_team_%d", botNumber));
 
 	if (strnull(custom_name))
 	{
+		if (isCTF())
+		{
+			return ctf_names[(int)bound(0, botNumber, sizeof(ctf_names) / sizeof(ctf_names[0]) - 1)];
+		}
 		return names[(int)bound(0, botNumber, sizeof(names) / sizeof(names[0]) - 1)];
 	}
 
@@ -324,14 +350,22 @@ char* BotNameFriendly(int botNumber)
 
 char* BotNameGeneric(int botNumber)
 {
-	char *names[] =
+	char* names[] =
 		{ "/ bro", "/ goldenboy", "/ tincan", "/ grue", "/ dizzy", "/ daisy", "/ denzil", "/ dora",
-				"/ shortie", "/ machina", "/ gudgie", "/ scoosh", "/ frazzle", "/ pop", "/ junk",
-				"/ overflow" };
+			"/ shortie", "/ machina", "/ gudgie", "/ scoosh", "/ frazzle", "/ pop", "/ junk",
+			"/ overflow" };
+
+	char *ctf_names[] =
+		{ "/ Hippo", "/ Velokitty", "/ Shiny", "/ Zagg", "/ Micro", "/ Elfeo", "/ Malice", "/ Killton" };
+
 	char *custom_name = cvar_string(va("k_fb_name_%d", botNumber));
 
 	if (strnull(custom_name))
 	{
+		if (isCTF())
+		{
+			return ctf_names[(int)bound(0, botNumber, sizeof(ctf_names) / sizeof(ctf_names[0]) - 1)];
+		}
 		return names[(int)bound(0, botNumber, sizeof(names) / sizeof(names[0]) - 1)];
 	}
 

--- a/src/bot_movement.c
+++ b/src/bot_movement.c
@@ -434,6 +434,7 @@ void BotSetCommand(gedict_t *self)
 	vec3_t direction;
 
 	BotPerformRocketJump(self);
+	BotPerformHook(self);
 
 	if (cmd_msec)
 	{

--- a/src/bot_world.c
+++ b/src/bot_world.c
@@ -71,7 +71,7 @@ static qbool VisibilityTest(gedict_t *self, gedict_t *visible_object, float min_
 {
 	vec3_t temp;
 
-	if (visible_object->s.v.takedamage)
+	if (visible_object->s.v.takedamage || visible_object->ctf_flag & CTF_RUNE_MASK)
 	{
 		// Can only see invisible objects when they're attacking
 		if ((g_globalvars.time < visible_object->invisible_finished)

--- a/src/client.c
+++ b/src/client.c
@@ -1577,7 +1577,8 @@ void ClientConnect(void)
 	}
 
 	// qqshka: force damn colors in CTF.
-	if (isCTF())
+	// doing this seems to stop the bots from doing it properly
+	if (isCTF() && !self->isBot)
 	{
 		int red = 0; // Keeps track of which team and colors to set for new player
 

--- a/src/commands.c
+++ b/src/commands.c
@@ -4575,16 +4575,6 @@ void UserMode(float umode)
 		um = "matchless"; // use configs/usermodes/matchless instead of configs/usermodes/ffa in matchless mode
 	}
 
-	if (streq(um, "ctf") && bots_enabled() && !sv_invoked)
-	{
-		if (bots_enabled())
-		{
-			G_sprint(self, PRINT_HIGH, "Disable bots first with %s\n", redtext("/botcmd disable"));
-
-			return;
-		}
-	}
-
 	//for 1on1 / 2on2 / 4on4 and ffa commands manipulation
 	//0 - no one, 1 - admins, 2 elected admins too
 	//3 - only real real judges, 4 - elected judges too

--- a/src/ctf.c
+++ b/src/ctf.c
@@ -32,11 +32,15 @@
 #define CARRIER_DEFEND_TIME  4
 
 void DropFlag(gedict_t *flag, qbool tossed);
-void PlaceFlag(void);
 void FlagThink(void);
 void FlagTouch(void);
 void SP_item_flag_team1(void);
 void SP_item_flag_team2(void);
+
+#ifdef BOT_SUPPORT
+void BotsFlag1Dropped(gedict_t* ent);
+void BotsFlag2Dropped(gedict_t* ent);
+#endif
 
 // Allows us to add flags (or other items) to dm maps when ctfing without actually changing bsp
 void G_CallSpawn(gedict_t *ent);
@@ -105,6 +109,10 @@ void SP_item_flag_team1(void)
 	}
 
 	spawn_item_flag();
+
+#ifdef BOT_SUPPORT
+	BotsFlag1Dropped(self);
+#endif
 }
 
 void SP_item_flag_team2(void)
@@ -120,6 +128,13 @@ void SP_item_flag_team2(void)
 	}
 
 	spawn_item_flag();
+
+#ifdef BOT_SUPPORT
+	if (bots_enabled())
+	{
+		BotsFlag2Dropped(self);
+	}
+#endif
 }
 
 // would love to know what a ctf wall is :O!
@@ -282,6 +297,12 @@ void FlagThink(void)
 		self->cnt2 += 0.1;
 		if (g_globalvars.time > self->super_time)
 		{
+#ifdef BOT_SUPPORT
+			if (bots_enabled())
+			{
+				self->fb.item_taken(self, other);
+			}
+#endif
 			RegenFlag(self);
 			G_bprint(2, "The %s flag has been returned\n",
 						redtext(((int)self->s.v.items & IT_KEY1) ? "BLUE" : "RED"));
@@ -439,6 +460,13 @@ void FlagTouch(void)
 			k_nochange = 0;	// Set it so it should update scores at next attempt.
 			refresh_plus_scores();
 
+#ifdef BOT_SUPPORT
+			if (bots_enabled())
+			{
+				self->fb.item_taken(self, other);
+			}
+#endif
+
 			return;
 		}
 	}
@@ -475,6 +503,13 @@ void FlagTouch(void)
 		owner->s.v.effects = (int)owner->s.v.effects | EF_FLAG1;
 	}
 	setmodel(self, "");
+
+#ifdef BOT_SUPPORT
+	if (bots_enabled())
+	{
+		self->fb.item_taken(self, other);
+	}
+#endif
 }
 
 void FlagResetOwner(void)

--- a/src/fb_globals.c
+++ b/src/fb_globals.c
@@ -290,6 +290,16 @@ qbool EnemyDefenceless(gedict_t *self)
 	return false;
 }
 
+qbool EnemyHasFlag(gedict_t* self)
+{
+	gedict_t* enemy = &g_edicts[self->s.v.enemy];
+	if (self->s.v.enemy == 0)
+	{
+		return false;
+	}
+	return enemy->ctf_flag & CTF_FLAG;
+}
+
 gedict_t* FirstZoneMarker(int zone)
 {
 	return zone_head[zone - 1];

--- a/src/maps_map_e2m2.c
+++ b/src/maps_map_e2m2.c
@@ -1,0 +1,44 @@
+#ifdef BOT_SUPPORT
+
+#include "g_local.h"
+
+// FIXME: Globals
+extern gedict_t *markers[];
+
+static float goal_discharge_marker(gedict_t* self, gedict_t* marker)
+{
+	// No need to check if we have the lg, as the bot will always pick it up when going to
+	// discharge. Otherwise the bot will start going for quad / flag then go back after changing goal.
+	if (self->deaths == 0 && self->team_no == 0)
+	{
+		return 99999;
+	}
+
+	return 0;
+}
+
+static qbool fb_discharge_marker_touch(gedict_t* ent, gedict_t* player)
+{
+	self->fb.look_object = ent;
+	AssignVirtualGoal(ent);
+	return false;
+}
+
+void BotsSetUpE2M2DischargeMarker(gedict_t* marker)
+{
+	marker->fb.desire = goal_discharge_marker;
+	marker->fb.item_touch = fb_discharge_marker_touch;
+}
+
+
+qbool E2M2DischargeLogic(gedict_t *self)
+{
+	if (self->fb.touch_marker && self->fb.touch_marker->fb.T & MARKER_E2M2_DISCHARGE && self->deaths == 0 && self->team_no == 0)
+	{
+		return true;
+	}
+
+	return false;
+}
+
+#endif

--- a/src/match.c
+++ b/src/match.c
@@ -2703,7 +2703,8 @@ void PlayerReady(qbool startIdlebot)
 	self->k_teamnum = 0;
 
 	// force red or blue color if ctf
-	if (isCTF())
+	// doing this seems to stop the bots from doing it properly
+	if (isCTF() && !self->isBot)
 	{
 		if (streq(getteam(self), "blue"))
 		{

--- a/src/route_fields.c
+++ b/src/route_fields.c
@@ -27,7 +27,7 @@ void SetGoalForMarker(int goal, gedict_t *marker)
 		return;
 	}
 
-	marker->fb.goals[goal - 1].next_marker_rj = marker->fb.goals[goal - 1].next_marker = marker;
+	marker->fb.goals[goal - 1].next_marker_hook = marker->fb.goals[goal - 1].next_marker_rj = marker->fb.goals[goal - 1].next_marker = marker;
 	marker->fb.G_ = goal;
 }
 
@@ -74,7 +74,7 @@ void SetZone(int zone, int marker_number)
 	z = &marker->fb.zones[zone];
 
 	marker->fb.S_ = subzone_indexes[zone]++;
-	z->marker_rj = z->next_rj = z->marker = z->reverse_marker = z->next = z->reverse_next = marker;
+	z->marker_hook = z->next_hook = z->marker_rj = z->next_rj = z->marker = z->reverse_marker = z->next = z->reverse_next = marker;
 	marker->fb.Z_ = zone + 1;
 
 	AddZoneMarker(marker);
@@ -212,6 +212,7 @@ void RemovePath(gedict_t *source, int path_number)
 	source->fb.paths[path_number].next_marker = NULL;
 	source->fb.paths[path_number].time = 0;
 	source->fb.paths[path_number].rj_time = 0;
+	source->fb.paths[path_number].hook_time = 0;
 }
 
 int AddPath(gedict_t *source, gedict_t *next)
@@ -243,6 +244,7 @@ int AddPath(gedict_t *source, gedict_t *next)
 		source->fb.paths[place].flags = 0;
 		source->fb.paths[place].time = 0;
 		source->fb.paths[place].rj_time = 0;
+		source->fb.paths[place].hook_time = 0;
 	}
 
 	return place;

--- a/src/route_lookup.c
+++ b/src/route_lookup.c
@@ -11,9 +11,13 @@
 #include "g_local.h"
 
 float SubZoneArrivalTime(float zone_time, gedict_t *middle_marker, gedict_t *from_marker,
-							qbool rl_routes)
+							qbool rl_routes, qbool hook_routes)
 {
-	if (rl_routes)
+	if (hook_routes)
+	{
+		return (zone_time + middle_marker->fb.subzones[from_marker->fb.S_].hook_time);
+	}
+	else if (rl_routes)
 	{
 		return (zone_time + middle_marker->fb.subzones[from_marker->fb.S_].rj_time);
 	}
@@ -46,7 +50,7 @@ float SightFromTime(gedict_t *from_marker, gedict_t *to_marker)
 			to_marker->fb.zones[from_marker->fb.Z_ - 1].sight_from_time : 0.0f);
 }
 
-void ZoneMarker(gedict_t *from_marker, gedict_t *to_marker, qbool path_normal, qbool rl_jump_routes)
+void ZoneMarker(gedict_t *from_marker, gedict_t *to_marker, qbool path_normal, qbool rl_jump_routes, qbool hook_routes)
 {
 	fb_zone_t *zone;
 
@@ -68,6 +72,9 @@ void ZoneMarker(gedict_t *from_marker, gedict_t *to_marker, qbool path_normal, q
 	{
 		middle_marker = rl_jump_routes ? zone->marker_rj : zone->marker;
 		zone_time = rl_jump_routes ? zone->rj_time : zone->time;
+
+		middle_marker = hook_routes ? zone->marker_hook : zone->marker;
+		zone_time = hook_routes ? zone->hook_time : zone->time;
 	}
 	else
 	{
@@ -77,7 +84,7 @@ void ZoneMarker(gedict_t *from_marker, gedict_t *to_marker, qbool path_normal, q
 }
 
 gedict_t* ZonePathMarker(gedict_t *from_marker, gedict_t *to_marker, qbool path_normal,
-							qbool rl_jump_routes)
+							qbool rl_jump_routes, qbool hook_routes)
 {
 	if ((from_marker == NULL) || (to_marker == NULL) || (to_marker->fb.Z_ == 0))
 	{
@@ -89,6 +96,11 @@ gedict_t* ZonePathMarker(gedict_t *from_marker, gedict_t *to_marker, qbool path_
 		if (rl_jump_routes)
 		{
 			return from_marker->fb.zones[to_marker->fb.Z_ - 1].next_rj;
+		}
+
+		if (hook_routes)
+		{
+			return from_marker->fb.zones[to_marker->fb.Z_ - 1].next_hook;
 		}
 
 		return from_marker->fb.zones[to_marker->fb.Z_ - 1].next;
@@ -133,7 +145,7 @@ gedict_t* SightMarker(gedict_t *from_marker, gedict_t *to_marker, float max_dist
 				if (g_globalvars.trace_fraction == 1)
 				{
 					// 
-					traveltime = SubZoneArrivalTime(zone_time, middle_marker, marker_, false);
+					traveltime = SubZoneArrivalTime(zone_time, middle_marker, marker_, false, false);
 					if (look_traveltime > traveltime)
 					{
 						// Teleports don't count

--- a/src/runes.c
+++ b/src/runes.c
@@ -9,6 +9,7 @@ void RuneRespawn(void);
 void RuneTouch(void);
 void RuneResetOwner(void);
 char* GetRuneSpawnName(void);
+void BotsRuneDropped(gedict_t* rune);
 
 void DoDropRune(int rune, qbool on_respawn)
 {
@@ -67,18 +68,22 @@ void DoDropRune(int rune, qbool on_respawn)
 	if (rune & CTF_RUNE_RES)
 	{
 		setmodel(item, "progs/end1.mdl");
+		item->tp_flags = it_rune1;
 	}
 	else if (rune & CTF_RUNE_STR)
 	{
 		setmodel(item, "progs/end2.mdl");
+		item->tp_flags = it_rune2;
 	}
 	else if (rune & CTF_RUNE_HST)
 	{
 		setmodel(item, "progs/end3.mdl");
+		item->tp_flags = it_rune3;
 	}
 	else if (rune & CTF_RUNE_RGN)
 	{
 		setmodel(item, "progs/end4.mdl");
+		item->tp_flags = it_rune4;
 	}
 
 	setsize(item, -16, -16, 0, 16, 16, 56);
@@ -91,6 +96,13 @@ void DoDropRune(int rune, qbool on_respawn)
 	{
 		sound(item, CHAN_VOICE, "items/itembk2.wav", 1, ATTN_NORM);	// play respawn sound
 	}
+
+#ifdef BOT_SUPPORT
+	if (bots_enabled())
+	{
+		BotsRuneDropped(item);
+	}
+#endif
 }
 
 void DoTossRune(int rune)
@@ -124,18 +136,22 @@ void DoTossRune(int rune)
 	if (rune & CTF_RUNE_RES)
 	{
 		setmodel(item, "progs/end1.mdl");
+		item->tp_flags = it_rune1;
 	}
 	else if (rune & CTF_RUNE_STR)
 	{
 		setmodel(item, "progs/end2.mdl");
+		item->tp_flags = it_rune2;
 	}
 	else if (rune & CTF_RUNE_HST)
 	{
 		setmodel(item, "progs/end3.mdl");
+		item->tp_flags = it_rune3;
 	}
 	else if (rune & CTF_RUNE_RGN)
 	{
 		setmodel(item, "progs/end4.mdl");
+		item->tp_flags = it_rune4;
 	}
 
 	setorigin(item, self->s.v.origin[0], self->s.v.origin[1], self->s.v.origin[2] - 24);
@@ -144,6 +160,13 @@ void DoTossRune(int rune)
 	item->touch = (func_t) RuneTouch;
 	item->s.v.nextthink = g_globalvars.time + 0.75;
 	item->think = (func_t) RuneResetOwner;
+
+#ifdef BOT_SUPPORT
+	if (bots_enabled())
+	{
+		BotsRuneDropped(item);
+	}
+#endif
 }
 
 void DropRune(void)
@@ -272,6 +295,13 @@ void RuneTouch(void)
 		self->s.v.nextthink = g_globalvars.time + 90;
 	}
 
+#ifdef BOT_SUPPORT
+	if (bots_enabled() && other->isBot)
+	{
+		self->fb.item_touch(self, other);
+	}
+#endif
+
 	if (other->ctf_flag & CTF_RUNE_MASK)
 	{
 		if (g_globalvars.time > other->rune_notify_time)
@@ -317,6 +347,15 @@ void RuneTouch(void)
 	sound(other, CHAN_ITEM, "weapons/lock4.wav", 1, ATTN_NORM);
 	stuffcmd(other, "bf\n");
 	ent_remove(self);
+
+	TeamplayEventItemTaken(other, self);
+
+#ifdef BOT_SUPPORT
+	if (bots_enabled() && other->isBot)
+	{
+		self->fb.item_taken(self, other);
+	}
+#endif
 }
 
 char* GetRuneSpawnName(void)


### PR DESCRIPTION
Allowed KTX Frogbots to play CTF matches. There are a lot of changes here so I appreciate it will probably take a long time to get this to the point where it can be merged, but I will try and respond as quickly as possible :)

# General Features / Changes
- Added a new command 'botcmd gomarker' for k_fb_options 3 < 3. Bots will all abandon their current goals and run to the marker the player was looking at when they used this command. Useful for debugging movement on complex maps. This command is admin only.
- Added functionality for bots to shoot buttons and doors. This has to be added explicitly in the .bot file.
	- Added a new path flag LOOK_BUTTON. This marks a path from a regular marker to a button. Bots won't move along this path, it is used to show them where to look when shooting the button.
- Increased NUMBER_SUBZONES from 32 to 128, since all the CTF maps have very large rooms. This is not strictly necessary, but it makes adding support to maps much easier.
- Bots will abandon goals if a teammate is already going for them, except artefacts and flags.

# CTF Support
- Bots now play CTF! They will (attempt to) capture and return the flag and grab runes.
	- Bots prioritise runes in this order, from best to worst: res, str, hst, rgn
- Bots each have one of 3 roles - attack, defend, midfield
	- Attackers will try and cap the flag
	- Midfielders will prioritise quad
	- Defenders will stay closer to the base and try to defend
	- Defence points are set manually in the .bot file.
	- Bots are added with roles in this order: attacker, midfield, defend, attack, midfield, etc.
	- Depending on the bots role, it will ignore the distance of relevant goals when deciding a goal
- Bots will prioritise enemies carrying their flag.
- Bots carrying a flag won't chase enemies.
- Increased bot lookahead time for CTF.
- Bots can now use the grappling hook. Hook paths must be added explicitly in the .bot file.
- Updated bot messages.
	- Going for flag
	- Base safe / not safe
	- All messages include whether the bot has the flag / which rune they have.
- For CTF, .bot filenames must end in _ctf to distinguish them from other modes, as the item ids are different.
- On E2M2, bots on the red team will grab lg and discharge when they first spawn.
- Added CTF names (this is just for fun and I can remove them if you want!)

# Known Issues
These are all not too high priority as far as I can tell, and I haven't been able to figure them out so far.
- team1 and team2 spawns were not automatically turned into markers. Unfortunately, I noticed this relatively late on, so all the .bot files I made have a custom marker right next to all the spawn points instead. It would be easy to fix the spawn points to make them markers automatically, but this would ruin the marker numbering in all the bot files I created and any other bot files created for maps with these spawns.
- If a player adds some bots, changes teams and adds more bots, some of the bots will be the wrong colour on the scoreboard. Can't work out why this is as it works fine in 4on4.
- All the movement debug logging doesn't include hook routes yet.
- I had to add checks for NULL to bot_botenemy.c, line 140 due to crashes. As far as I can tell, this could have caused crashes anyway, I'm not sure if this is linked to the CTF code or not.

There are several other parts where I'm not sure if I've made good decisions or not, these are marked in my code with 'TODO hiipe', I can summarise these here if that would be preferable.

I hope that covers everything, this is my first time trying to contribute to a big project like this, so I would appreciate any feedback.

Thanks,
hiipe