### PR TITLE
Randomize the processing order of the initial spawn

### DIFF
--- a/src/match.c
+++ b/src/match.c
@@ -897,9 +897,10 @@ void SM_PrepareMap(void)
 // put clients in server and reset some params
 static void SM_PrepareClients(void)
 {
-	int hdc, i;
+	int hdc, i, j, player_count = 0;
 	char *pl_team;
-	gedict_t *p;
+	gedict_t *p, *temp;
+	gedict_t *players[MAX_CLIENTS];
 	qbool hoonymode_reset = isHoonyModeAny() && HM_current_point() > 0;
 
 	k_teamid = 666;
@@ -907,8 +908,23 @@ static void SM_PrepareClients(void)
 	trap_executecmd(); // <- this really needed
 
 	initial_match_spawns = true;
+
 	for (p = world; (p = find_plr(p));)
 	{
+		players[player_count++] = p;
+	}
+
+	for (i = player_count - 1; i > 0; i--)
+	{
+		j = rand() % (i + 1);
+		temp = players[i];
+		players[i] = players[j];
+		players[j] = temp;
+	}
+
+	for (j = 0; j < player_count; j++)
+	{
+		p = players[j];
 		if (!k_matchLess)
 		{
 			// skip setup k_teamnum in matchLess mode


### PR DESCRIPTION
Players are assigned the first available spot in the svs.clients array when they connect to a mvdsv server. On an empty server, this means that player1 is placed at svs.clients[0], player2 at svs.clients[1], and so on.

KTX iterates over svs.clients at the start of a match to decide where each player will spawn. This becomes problematic when there are fewer spawn points than players. A good example is dm3, which only has six spawns.

In the scenario where players connect to an empty server, they occupy the indexes 0 through 7 in the svs.clients array and are processed in this predictable order. This means player1 gets a random spawn before player2, player2 before player3, and so forth.

When it reaches player7, all spawn points are occupied. A random spawn is selected, and the player at that spawn point will be telefragged. Similarly, player8, the last to be processed, will also cause a telefrag.

By randomizing the processing order of the initial spawn, we eliminate the predictability of player placement in the array, thereby removing the ability to manipulate telefrag outcomes.