### PR TITLE
RACE: Trim trailing \n when reading top scores.

### DIFF
--- a/src/race.c
+++ b/src/race.c
@@ -3546,6 +3546,7 @@ char* race_fgets(char *buf, int limit)
 	{
 		if ((*string++ = c) == '\n')
 		{
+			string--;
 			break;
 		}
 	}


### PR DESCRIPTION
Introduced back in 2011 via 9fc1a31 but hidden thanks to strlcpy incorrectly using source buffer length (and risking buffer overflow). After fe38404 strlcpy was invoked with destination buffer length, and source buffer was copied up until NUL-termination and thus incorrectly included the \n.

Found by @VVD, fixes #388