### PR TITLE
Fix Normal QW respawns

### DIFF
--- a/include/g_local.h
+++ b/include/g_local.h
@@ -240,9 +240,6 @@ typedef enum
 
 // g_utils.c
 
-// K_SPW_0_NONRANDOM changes "Normal QW respawns" to "pre-qtest nonrandom respawns"
-#define K_SPW_0_NONRANDOM
-
 void g_random_seed(int);
 float g_random(void);
 float crandom(void);

--- a/src/client.c
+++ b/src/client.c
@@ -1037,9 +1037,7 @@ gedict_t* Sub_SelectSpawnPoint(char *spawnname)
 		return spot;
 	}
 
-// K_SPW_0_NONRANDOM changes "Normal QW respawns" to "pre-qtest nonrandom respawns"
-#ifdef K_SPW_0_NONRANDOM
-	if (k_spw == 0)
+	if (k_spw == -1)
 	{
 		static gedict_t *last_spot = g_edicts; // basically, g_edicts is same as world, but we can't initialize static variable with world.
 
@@ -1051,7 +1049,6 @@ gedict_t* Sub_SelectSpawnPoint(char *spawnname)
 
 		return last_spot;
 	}
-#endif
 
 // ok, find all spots that don't have players nearby
 

--- a/src/commands.c
+++ b/src/commands.c
@@ -2654,7 +2654,7 @@ void ReportMe(void)
 
 void ToggleRespawns(void)
 {
-	int k_spw = bound(0, cvar("k_spw"), 4);
+	int k_spw = bound(-1, cvar("k_spw"), 4);
 
 	if (match_in_progress)
 	{
@@ -2663,7 +2663,7 @@ void ToggleRespawns(void)
 
 	if (++k_spw > 4)
 	{
-		k_spw = 0;
+		k_spw = -1;
 	}
 
 	cvar_fset("k_spw", k_spw);

--- a/src/g_utils.c
+++ b/src/g_utils.c
@@ -2661,13 +2661,11 @@ char* respawn_model_name(int mdl_num)
 {
 	switch (mdl_num)
 	{
-// K_SPW_0_NONRANDOM changes "Normal QW respawns" to "pre-qtest nonrandom respawns"
-#ifdef K_SPW_0_NONRANDOM
-		case 0:
+		case -1:
 			return "pre-qtest nonrandom respawns";
-#else
-		case 0:  return "Normal QW respawns";
-#endif
+
+		case 0:
+			return "Normal QW respawns";
 
 		case 1:
 			return "KT SpawnSafety";
@@ -2690,6 +2688,9 @@ char* respawn_model_name_short(int mdl_num)
 {
 	switch (mdl_num)
 	{
+		case -1:
+			return "QTEST";
+
 		case 0:
 			return "QW";
 


### PR DESCRIPTION
In 2012, commit 3043a91 imported phil's hoonymod into KTX, changing normal QW respawns from being randomized to cycling through the list of spawns in a predetermined order.

From what I can tell, hoonymod no longer even uses k_spw 0. However, just in case, I've added k_spw -1, which allows the use of non-randomized spawns if anyone ever wants that again.