### PR TITLE
Adjust lower bot skill thresholds

### DIFF
--- a/include/progs.h
+++ b/include/progs.h
@@ -528,6 +528,7 @@ typedef struct fb_botskill_s {
 	fb_botaim_t aim_params[2];
 
 	float movement;
+	qbool use_rocketjumps;
 	float combat_jump_chance;
 	float missile_dodge_time;				// minimum time in seconds before bot dodges missile
 
@@ -572,7 +573,7 @@ typedef struct fb_entvars_s {
 
 	int oldsolid;								// need to keep track of this for hazard calculations
 
-	// these determine the desire for items for each player 
+	// these determine the desire for items for each player
 	//   (not just for bots ... bot's desire can take enemy's desire into consideration)
 	fb_desire_funcref_t desire;
 	float desire_armor1;
@@ -608,7 +609,7 @@ typedef struct fb_entvars_s {
 
 	qbool fl_marker;							// true if the current item is considered a marker (used when finding all objects in given radius)
 	//struct gedict_s* next;
-	
+
 	// Goal evaluation
 	struct gedict_s* best_goal;
 	float best_goal_score;
@@ -1196,7 +1197,7 @@ typedef struct gedict_s
 	int lgc_distance_hits[LGCMODE_DISTANCE_BUCKETS];
 // }
 
-// { 
+// {
 	// let mvdsv know when player has teleported, and adjust for high-ping
 	int teleported;
 // }

--- a/src/bot_botimp.c
+++ b/src/bot_botimp.c
@@ -153,15 +153,62 @@ void RegisterSkillVariables(void)
 	RegisterCvar(FB_CVAR_OPPONENT_MIDAIR_VOLATILITY_INCREASE);
 }
 
-qbool SetAttributesBasedOnSkill(int skill)
-{
-	char *cfg_name;
-	qbool customised = false;
-	int aimskill;
+void setLgcModeSkillAttributes(int skill, int aimskill) {
+	// Keep LGC bot skill attributes separate so we can change
+	// general skill attributes without affecting LGC mode, so players
+	// can still play LGC mode on same terms as old records.
 
-	skill = bound(MIN_FROGBOT_SKILL, skill, MAX_FROGBOT_SKILL);
-	aimskill = bound(MIN_FROGBOT_SKILL, skill, MAX_FROGBOT_AIM_SKILL);
+	// Old frogbot settings (items generally)
+	cvar_fset(FB_CVAR_ACCURACY, 45 - min(skill, 10) * 2.25);
+	cvar_fset(FB_CVAR_DODGEFACTOR, RangeOverSkill(skill, 0.0f, 1.0f));
+	cvar_fset(FB_CVAR_LOOKANYWHERE, RangeOverSkill(skill, 0.0f, 1.0f));
+	cvar_fset(FB_CVAR_LOOKAHEADTIME, RangeOverSkill(skill, 5.0f, 30.0f));
+	cvar_fset(FB_CVAR_PREDICTIONERROR, RangeOverSkill(skill, 1.0f, 0.0f));
+	cvar_fset(FB_CVAR_DISTANCEERROR, RangeOverSkill(skill, 0.15f, 0.0f));
 
+	// Old, but used to be global
+	cvar_fset(FB_CVAR_LGPREF, RangeOverSkill(skill, 0.2f, 1.0f));
+	cvar_fset(FB_CVAR_VISIBILITY, 0.7071067f - (0.02f * min(skill, 10))); // equivalent of 90 => 120 fov
+
+	cvar_fset(FB_CVAR_YAW_MIN_ERROR, RangeOverSkill(aimskill, 1.5, 1));
+	cvar_fset(FB_CVAR_YAW_MAX_ERROR, RangeOverSkill(aimskill, 4.5, 3));
+	cvar_fset(FB_CVAR_YAW_MULTIPLIER, RangeOverSkill(aimskill, 4, 2.5));
+	cvar_fset(FB_CVAR_YAW_SCALE, RangeOverSkill(aimskill, 5, 2));
+
+	cvar_fset(FB_CVAR_PITCH_MIN_ERROR, RangeOverSkill(aimskill, 1.5, 1));
+	cvar_fset(FB_CVAR_PITCH_MAX_ERROR, RangeOverSkill(aimskill, 4.5, 3));
+	cvar_fset(FB_CVAR_PITCH_MULTIPLIER, RangeOverSkill(aimskill, 4, 2));
+	cvar_fset(FB_CVAR_PITCH_SCALE, RangeOverSkill(aimskill, 5, 2));
+
+	cvar_fset(FB_CVAR_ATTACK_RESPAWNS, skill >= 15 ? 1 : 0);
+	cvar_fset(FB_CVAR_REACTION_TIME, RangeOverSkill(skill, 0.75f, 0.3f));
+	cvar_fset(FB_CVAR_REACTION_MOVETIME, RangeOverSkill(skill, 0.3f, 0.1f));
+
+	// Volatility
+	cvar_fset(FB_CVAR_MIN_VOLATILITY, 1.0f);
+	cvar_fset(FB_CVAR_MAX_VOLATILITY, RangeOverSkill(skill, 4.0f, 2.5f));
+	cvar_fset(FB_CVAR_INITIAL_VOLATILITY, RangeOverSkill(skill, 3.0f, 1.4f));
+	cvar_fset(FB_CVAR_REDUCE_VOLATILITY, RangeOverSkill(skill, 0.98f, 0.96f));
+	cvar_fset(FB_CVAR_OWNSPEED_VOLATILITY_THRESHOLD, RangeOverSkill(skill, 360, 450));
+	cvar_fset(FB_CVAR_OWNSPEED_VOLATILITY_INCREASE, RangeOverSkill(skill, 0.2f, 0.1f));
+	cvar_fset(FB_CVAR_ENEMYSPEED_VOLATILITY_THRESHOLD, RangeOverSkill(skill, 360, 450));
+	cvar_fset(FB_CVAR_ENEMYSPEED_VOLATILITY_INCREASE, RangeOverSkill(skill, 0.4f, 0.2f));
+	cvar_fset(FB_CVAR_ENEMYDIRECTION_VOLATILITY_INCREASE, RangeOverSkill(skill, 0.6f, 0.4f));
+	cvar_fset(FB_CVAR_PAIN_VOLATILITY_INCREASE, RangeOverSkill(skill, 0.5f, 0.1f));
+	cvar_fset(FB_CVAR_SELF_MIDAIR_VOLATILITY_INCREASE, RangeOverSkill(skill, 1.0f, 0.0f));
+	cvar_fset(FB_CVAR_OPPONENT_MIDAIR_VOLATILITY_INCREASE, RangeOverSkill(skill, 1.0f, 0.0f));
+
+	// Movement
+	cvar_fset(FB_CVAR_MOVEMENT_SKILL, RangeOverSkill(skill, 0.3f, 1.0f));
+	cvar_fset(FB_CVAR_MOVEMENT_DMM4WIGGLE, skill > 10 ? 1 : 0);
+	cvar_fset(FB_CVAR_MOVEMENT_DMM4WIGGLETOGGLE,
+				skill > 10 ? RangeOverSkill((skill - 10) * 2, 0.0f, 0.25f) : 0);
+	cvar_fset(FB_CVAR_MOVEMENT_WIGGLEFRAMES, RangeOverSkill(skill, 30, 20));
+	cvar_fset(FB_CVAR_COMBATJUMP_CHANCE, RangeOverSkill(skill, 0.03f, 0.1f));
+	cvar_fset(FB_CVAR_MISSILEDODGE_TIME, RangeOverSkill(skill, 1.0f, 0.5f));
+}
+
+void setSkillAttributes(int skill, int aimskill) {
 	// Old frogbot settings (items generally)
 	cvar_fset(FB_CVAR_ACCURACY, 45 - min(skill, 10) * 2.25);
 	cvar_fset(FB_CVAR_DODGEFACTOR, RangeOverSkill(skill, 0.0f, 1.0f));
@@ -211,6 +258,23 @@ qbool SetAttributesBasedOnSkill(int skill)
 	cvar_fset(FB_CVAR_MOVEMENT_WIGGLEFRAMES, RangeOverSkill(skill, 30, 20));
 	cvar_fset(FB_CVAR_COMBATJUMP_CHANCE, RangeOverSkill(skill, 0.0f, 0.1f));
 	cvar_fset(FB_CVAR_MISSILEDODGE_TIME, RangeOverSkill(skill, 1.0f, 0.5f));
+}
+
+qbool SetAttributesBasedOnSkill(int skill)
+{
+	char *cfg_name;
+	qbool customised = false;
+	int aimskill;
+
+	skill = bound(MIN_FROGBOT_SKILL, skill, MAX_FROGBOT_SKILL);
+	aimskill = bound(MIN_FROGBOT_SKILL, skill, MAX_FROGBOT_AIM_SKILL);
+
+	if (lgc_enabled()) {
+		G_bprint(2, "LGC mode enabled - using legacy bot skill attributes.\n");
+		setLgcModeSkillAttributes(skill, aimskill);
+	} else {
+		setSkillAttributes(skill, aimskill);
+	}
 
 	// Customise
 	{

--- a/src/bot_botimp.c
+++ b/src/bot_botimp.c
@@ -46,6 +46,7 @@
 #define FB_CVAR_OPPONENT_MIDAIR_VOLATILITY_INCREASE "k_fbskill_vol_opp_midair_incr"
 
 #define FB_CVAR_MOVEMENT_SKILL "k_fbskill_movement"
+#define FB_CVAR_USE_ROCKETJUMPS "k_fbskill_use_rocketjumps"
 #define FB_CVAR_MOVEMENT_DMM4WIGGLE "k_fbskill_dmm4wiggle"
 #define FB_CVAR_MOVEMENT_DMM4WIGGLETOGGLE "k_fbskill_dmm4wiggletoggle"
 #define FB_CVAR_MOVEMENT_WIGGLEFRAMES "k_fbskill_wiggleframes"
@@ -139,6 +140,7 @@ void RegisterSkillVariables(void)
 	RegisterCvar(FB_CVAR_ENEMYDIRECTION_VOLATILITY_INCREASE);
 
 	RegisterCvar(FB_CVAR_MOVEMENT_SKILL);
+	RegisterCvar(FB_CVAR_USE_ROCKETJUMPS);
 	RegisterCvar(FB_CVAR_MOVEMENT_DMM4WIGGLE);
 	RegisterCvar(FB_CVAR_MOVEMENT_WIGGLEFRAMES);
 	RegisterCvar(FB_CVAR_MOVEMENT_DMM4WIGGLETOGGLE);
@@ -166,24 +168,24 @@ qbool SetAttributesBasedOnSkill(int skill)
 	cvar_fset(FB_CVAR_LOOKANYWHERE, RangeOverSkill(skill, 0.0f, 1.0f));
 	cvar_fset(FB_CVAR_LOOKAHEADTIME, RangeOverSkill(skill, 5.0f, 30.0f));
 	cvar_fset(FB_CVAR_PREDICTIONERROR, RangeOverSkill(skill, 1.0f, 0.0f));
-	cvar_fset(FB_CVAR_DISTANCEERROR, RangeOverSkill(skill, 0.15f, 0.0f));
+	cvar_fset(FB_CVAR_DISTANCEERROR, RangeOverSkill(skill, 0.25f, 0.0f));
 
 	// Old, but used to be global
 	cvar_fset(FB_CVAR_LGPREF, RangeOverSkill(skill, 0.2f, 1.0f));
 	cvar_fset(FB_CVAR_VISIBILITY, 0.7071067f - (0.02f * min(skill, 10))); // equivalent of 90 => 120 fov
 
-	cvar_fset(FB_CVAR_YAW_MIN_ERROR, RangeOverSkill(aimskill, 1.5, 1));
-	cvar_fset(FB_CVAR_YAW_MAX_ERROR, RangeOverSkill(aimskill, 4.5, 3));
-	cvar_fset(FB_CVAR_YAW_MULTIPLIER, RangeOverSkill(aimskill, 4, 2.5));
-	cvar_fset(FB_CVAR_YAW_SCALE, RangeOverSkill(aimskill, 5, 2));
+	cvar_fset(FB_CVAR_YAW_MIN_ERROR, RangeOverSkill(aimskill, 3, 1));
+	cvar_fset(FB_CVAR_YAW_MAX_ERROR, RangeOverSkill(aimskill, 6, 3));
+	cvar_fset(FB_CVAR_YAW_MULTIPLIER, RangeOverSkill(aimskill, 5, 2.5));
+	cvar_fset(FB_CVAR_YAW_SCALE, RangeOverSkill(aimskill, 7, 2));
 
-	cvar_fset(FB_CVAR_PITCH_MIN_ERROR, RangeOverSkill(aimskill, 1.5, 1));
-	cvar_fset(FB_CVAR_PITCH_MAX_ERROR, RangeOverSkill(aimskill, 4.5, 3));
-	cvar_fset(FB_CVAR_PITCH_MULTIPLIER, RangeOverSkill(aimskill, 4, 2));
-	cvar_fset(FB_CVAR_PITCH_SCALE, RangeOverSkill(aimskill, 5, 2));
+	cvar_fset(FB_CVAR_PITCH_MIN_ERROR, RangeOverSkill(aimskill, 3, 1));
+	cvar_fset(FB_CVAR_PITCH_MAX_ERROR, RangeOverSkill(aimskill, 6, 3));
+	cvar_fset(FB_CVAR_PITCH_MULTIPLIER, RangeOverSkill(aimskill, 5, 2));
+	cvar_fset(FB_CVAR_PITCH_SCALE, RangeOverSkill(aimskill, 7, 2));
 
 	cvar_fset(FB_CVAR_ATTACK_RESPAWNS, skill >= 15 ? 1 : 0);
-	cvar_fset(FB_CVAR_REACTION_TIME, RangeOverSkill(skill, 0.75f, 0.3f));
+	cvar_fset(FB_CVAR_REACTION_TIME, RangeOverSkill(skill, 1.5f, 0.3f));
 	cvar_fset(FB_CVAR_REACTION_MOVETIME, RangeOverSkill(skill, 0.3f, 0.1f));
 
 	// Volatility
@@ -201,12 +203,13 @@ qbool SetAttributesBasedOnSkill(int skill)
 	cvar_fset(FB_CVAR_OPPONENT_MIDAIR_VOLATILITY_INCREASE, RangeOverSkill(skill, 1.0f, 0.0f));
 
 	// Movement
-	cvar_fset(FB_CVAR_MOVEMENT_SKILL, RangeOverSkill(skill, 0.3f, 1.0f));
+	cvar_fset(FB_CVAR_MOVEMENT_SKILL, RangeOverSkill(skill, 0.0f, 1.0f));
+	cvar_fset(FB_CVAR_USE_ROCKETJUMPS, skill > 5 ? 1 : 0);
 	cvar_fset(FB_CVAR_MOVEMENT_DMM4WIGGLE, skill > 10 ? 1 : 0);
 	cvar_fset(FB_CVAR_MOVEMENT_DMM4WIGGLETOGGLE,
 				skill > 10 ? RangeOverSkill((skill - 10) * 2, 0.0f, 0.25f) : 0);
 	cvar_fset(FB_CVAR_MOVEMENT_WIGGLEFRAMES, RangeOverSkill(skill, 30, 20));
-	cvar_fset(FB_CVAR_COMBATJUMP_CHANCE, RangeOverSkill(skill, 0.03f, 0.1f));
+	cvar_fset(FB_CVAR_COMBATJUMP_CHANCE, RangeOverSkill(skill, 0.0f, 0.1f));
 	cvar_fset(FB_CVAR_MISSILEDODGE_TIME, RangeOverSkill(skill, 1.0f, 0.5f));
 
 	// Customise
@@ -271,7 +274,7 @@ void SetAttribs(gedict_t *self, qbool customised)
 													5.0f);
 	self->fb.skill.enemydirection_volatility = bound(
 			0, cvar(FB_CVAR_ENEMYDIRECTION_VOLATILITY_INCREASE), 5.0f);
-	self->fb.skill.awareness_delay = bound(0, cvar(FB_CVAR_REACTION_TIME), 1.0f);
+	self->fb.skill.awareness_delay = bound(0, cvar(FB_CVAR_REACTION_TIME), 1.5f);
 	self->fb.skill.spawn_move_delay = bound(0, cvar(FB_CVAR_REACTION_MOVETIME), 1.0f);
 	self->fb.skill.pain_volatility = bound(0, cvar(FB_CVAR_PAIN_VOLATILITY_INCREASE), 2.0f);
 	self->fb.skill.self_midair_volatility = bound(0, cvar(FB_CVAR_SELF_MIDAIR_VOLATILITY_INCREASE),
@@ -281,6 +284,7 @@ void SetAttribs(gedict_t *self, qbool customised)
 
 	// Movement
 	self->fb.skill.movement = bound(0, cvar(FB_CVAR_MOVEMENT_SKILL), 1.0f);
+	self->fb.skill.use_rocketjumps = cvar(FB_CVAR_USE_ROCKETJUMPS) > 0;
 	self->fb.skill.wiggle_run_dmm4 = bound(0, (int)cvar(FB_CVAR_MOVEMENT_DMM4WIGGLE), 1.0f);
 	self->fb.skill.wiggle_run_limit = bound(0, (int)cvar(FB_CVAR_MOVEMENT_WIGGLEFRAMES), 45.0f);
 	self->fb.skill.wiggle_toggle = bound(0, cvar(FB_CVAR_MOVEMENT_DMM4WIGGLETOGGLE), 1.0f);

--- a/src/bot_botjump.c
+++ b/src/bot_botjump.c
@@ -94,6 +94,10 @@ void BotCanRocketJump(gedict_t *self)
 	{
 		self->fb.canRocketJump = self->fb.debug_path_rj;
 	}
+	else if (!self->fb.skill.use_rocketjumps)
+	{
+		self->fb.canRocketJump = false;
+	}
 	else if (has_rl && (self->s.v.waterlevel > 1)
 			&& (trap_pointcontents(self->s.v.origin[0], self->s.v.origin[1], self->s.v.origin[2])
 					== CONTENT_LAVA))


### PR DESCRIPTION
This PR adjust the lower thresholds of the bot skill levels with regards to aim, movement and reaction time.
* Skill 1 bots are now cannonfodder (so they are more suitable for someone completely new to the game).
* Bots only rocketjumps above skill 5. 
* Skill 20 should still be the same since i haven't touched the upper thresholds.
* LGC mode generally uses skill 10 however, so i kept the old settings for LGC mode to still be able to play that on same terms as before.

// Åke Vader