### PR TITLE
LEAVEMEALONE: players can't bother you in prewar

### DIFF
--- a/include/progs.h
+++ b/include/progs.h
@@ -953,6 +953,7 @@ typedef struct gedict_s
 	float fIllegalFPSWarnings;
 // ILLEGALFPS]
 
+	qbool leavemealone;
 	float shownick_time;					// used to force centerprint is off at desired time
 	clientType_t ct;						// client type for client edicts
 // { timing

--- a/src/client.c
+++ b/src/client.c
@@ -1740,7 +1740,7 @@ void PutClientInServer(void)
 	self->classname = "player";
 	self->s.v.health = 100;
 	self->s.v.takedamage = DAMAGE_AIM;
-	self->s.v.solid = SOLID_SLIDEBOX;
+	self->s.v.solid = self->leavemealone ? SOLID_TRIGGER : SOLID_SLIDEBOX;
 	self->s.v.movetype = MOVETYPE_WALK;
 	self->show_hostile = 0;
 	self->s.v.max_health = 100;
@@ -3697,6 +3697,16 @@ void PlayerPreThink(void)
 	CA_player_pre_think();
 
 	race_player_pre_think();
+
+	if (self->leavemealone)
+	{
+		if ((self->s.v.mins[0] == 0) || (self->s.v.mins[1] == 0))
+		{
+			// This can happen if the world 'squashes' a SOLID_NOT entity, mvdsv will turn into corpse
+			setsize(self, PASSVEC3(VEC_HULL_MIN), PASSVEC3(VEC_HULL_MAX));
+		}
+		setorigin(self, PASSVEC3(self->s.v.origin));
+	}	
 
 // brokenankle included here
 	if (self->s.v.button2 || self->brokenankle)

--- a/src/combat.c
+++ b/src/combat.c
@@ -462,6 +462,21 @@ void T_Damage(gedict_t *targ, gedict_t *inflictor, gedict_t *attacker, float dam
 		return;
 	}
 
+	// don't bounce around players in prewar who wish to be left alone
+	if (match_in_progress != 2 && targ->leavemealone)
+	{
+		if (attacker != targ && ((targ->ct == ctPlayer) && (attacker->ct == ctPlayer)))
+		{
+			return;
+		}
+		else if (dtTELE1 == targ->deathtype	// always do tele damage
+				|| dtTELE2 == targ->deathtype	// always do tele damage
+				|| dtTELE3 == targ->deathtype)	// always do tele damage
+		{
+			// telefrags still work, to avoid getting stuck
+		}
+	}
+
 	// can't damage other players in race
 	if (isRACE() && (attacker != targ))
 	{

--- a/src/commands.c
+++ b/src/commands.c
@@ -72,6 +72,7 @@ void CTFBasedSpawn(void);
 // } CTF
 void FragsDown(void);
 void FragsUp(void);
+void LeaveMeAlone(void);
 void ListWhoNot(void);
 void ModStatus1(void);
 void ModStatus2(void);
@@ -390,6 +391,7 @@ const char CD_NODESC[] = "no desc";
 #define CD_CTOCT			"Show octal charset table"
 #define CD_CTHEX			"Show hexadecimal charset table"
 #define CD_SHOWNICK			"pointed player's info"
+#define CD_LEAVEMEALONE			"can't shoot/bounce players in prewar"
 #define CD_TIME5			"set timelimit to 5 mins"
 #define CD_TIME10			"set timelimit to 10 mins"
 #define CD_TIME15			"set timelimit to 15 mins"
@@ -753,6 +755,7 @@ cmd_t cmds[] =
 	{ "sct_hex", 					ShowCharsetTableHexa, 			0, 			CF_BOTH, 																CD_CTHEX },
 	{ "about", 						ShowVersion, 					0, 			CF_BOTH | CF_MATCHLESS, 												CD_ABOUT },
 	{ "shownick", 					ShowNick, 						0, 			CF_PLAYER | CF_PARAMS, 													CD_SHOWNICK },
+	{ "leavemealone", 				LeaveMeAlone, 					0, 			CF_PLAYER | CF_PARAMS, 													CD_LEAVEMEALONE },
 	{ "time5", 						DEF(TimeSet), 					5.0f, 		CF_PLAYER | CF_SPC_ADMIN, 												CD_TIME5 },
 	{ "time10", 					DEF(TimeSet), 					10.0f, 		CF_PLAYER | CF_SPC_ADMIN, 												CD_TIME10 },
 	{ "time15", 					DEF(TimeSet), 					15.0f, 		CF_PLAYER | CF_SPC_ADMIN, 												CD_TIME15 },
@@ -4065,6 +4068,33 @@ ok:
 
 	self->need_clearCP = 1;
 	self->shownick_time = g_globalvars.time + 0.8; // clear centerprint at this time
+}
+
+void LeaveMeAlone(void)
+{
+	if (match_in_progress)
+	{
+		return;
+	}
+
+	if (isRA() || isRACE())
+	{
+		return;
+	}
+
+	if (self->leavemealone)
+	{
+		G_bprint(2, "%s %s\n", self->netname, redtext("no longer wants to be left alone"));
+		self->s.v.solid = SOLID_SLIDEBOX;
+	}
+	else
+	{
+		G_bprint(2, "%s %s\n", self->netname, redtext("wants to be left alone"));
+		self->s.v.solid = SOLID_TRIGGER;
+	}
+
+	setorigin(self, PASSVEC3(self->s.v.origin));
+	self->leavemealone = !self->leavemealone;
 }
 
 // qqshka

--- a/src/match.c
+++ b/src/match.c
@@ -914,6 +914,7 @@ static void SM_PrepareClients(void)
 	for (p = world; (p = find_plr(p));)
 	{
 		players[player_count++] = p;
+		p->leavemealone = false;		// can't have this enabled during match
 	}
 
 	for (i = player_count - 1; i > 0; i--)

--- a/src/triggers.c
+++ b/src/triggers.c
@@ -715,7 +715,7 @@ void teleport_touch(void)
 	}
 
 // only teleport living creatures
-	if (ISDEAD(other) || (!isRACE() && (other->s.v.solid != SOLID_SLIDEBOX)))
+	if (ISDEAD(other) || (!isRACE() && (other->s.v.solid != SOLID_SLIDEBOX) && !other->leavemealone))
 	{
 		return;
 	}

--- a/src/weapons.c
+++ b/src/weapons.c
@@ -377,6 +377,12 @@ void TraceAttack(float damage, vec3_t dir, qbool send_effects)
 		return;
 	}
 
+	//can't touch/damage players who want to be left alone
+	if (PROG_TO_EDICT(g_globalvars.trace_ent)->ct == ctPlayer && PROG_TO_EDICT(g_globalvars.trace_ent)->leavemealone)
+	{
+		return;
+	}
+
 	if (PROG_TO_EDICT(g_globalvars.trace_ent)->s.v.takedamage)
 	{
 		if (PROG_TO_EDICT(g_globalvars.trace_ent)->ct == ctPlayer)
@@ -960,6 +966,11 @@ void T_MissileTouch(void)
 		return;
 	}
 
+	if (other->leavemealone)
+	{
+		return;
+	}
+
 	if (self->voided)
 	{
 		return;
@@ -1323,6 +1334,12 @@ void GrenadeTouch(void)
 		return;
 	}
 
+	// can't touch players who want to be left alone
+	if (other->leavemealone)
+	{
+		return;
+	}
+
 	if (other->s.v.takedamage)
 	{
 		if (other->ct == ctPlayer)
@@ -1513,6 +1530,12 @@ void spike_touch(void)
 	}
 
 	if (race_ignore_spike(self, other))
+	{
+		return;
+	}
+
+	// can't touch players who want to be left alone
+	if (other->leavemealone)
 	{
 		return;
 	}


### PR DESCRIPTION
Some players like to use prewar to practice movement or trick jumps and don't want to be bothered by other players shooting around. /leavemealone prevents your player from being knocked around by other players' fire.