### PR TITLE
Update q_shared.h

### DIFF
--- a/include/q_shared.h
+++ b/include/q_shared.h
@@ -143,7 +143,7 @@ size_t strlcat(char *dst, const char *src, size_t siz);
 typedef unsigned char byte;
 typedef enum
 {
-	false, true
+	qfalse, qtrue
 } qbool;
 
 #ifndef NULL


### PR DESCRIPTION
In C, starting from the C23 standard, false is defined as a keyword, which means it cannot be used as an identifier.