### PR TITLE
Update cmake min version requirement to 3.10

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.9.0)
+cmake_minimum_required(VERSION 3.10.0)
 
 # Set project name and languge.
 project(qwprogs C)

--- a/tools/q3asm/CMakeLists.txt
+++ b/tools/q3asm/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.9.0)
+cmake_minimum_required(VERSION 3.10.0)
 
 project(q3asm C)
 add_executable(q3asm q3asm.c q3vm.c cmdlib.c)


### PR DESCRIPTION
Compatibility with CMake < 3.10 will be removed from a future version of CMake. Updating the min version in advance.